### PR TITLE
Populate exceptions with errors from the response

### DIFF
--- a/src/Intercom/Exception/IntercomException.php
+++ b/src/Intercom/Exception/IntercomException.php
@@ -49,8 +49,8 @@ class IntercomException extends BadResponseException
         $e->setRequest($request);
 
         // Sets the errors if the error response is the standard Intercom error type
-        if (!static::isValidIntercomError($response->json())) {
-            $e->errors = $response->json()['errors'];
+        if (static::isValidIntercomError($response->json())) {
+            $e->setErrors($response->json()['errors']);
         }
 
         return $e;
@@ -61,7 +61,7 @@ class IntercomException extends BadResponseException
      * @param $response_body
      * @return bool
      */
-    private function isValidIntercomError($response_body)
+    private static function isValidIntercomError($response_body)
     {
         if (array_key_exists('type', $response_body) &&
             $response_body['type'] == 'error.list' &&
@@ -80,5 +80,10 @@ class IntercomException extends BadResponseException
     public function getErrors()
     {
         return $this->errors;
+    }
+
+    public function setErrors($errors)
+    {
+        $this->errors = $errors;
     }
 }

--- a/tests/Intercom/Exception/IntercomExceptionTest.php
+++ b/tests/Intercom/Exception/IntercomExceptionTest.php
@@ -1,0 +1,21 @@
+<?php
+
+namespace Intercom;
+
+class IntercomExceptionTest extends IntercomTestCase
+{
+    public function test404Exception()
+    {
+        try {
+            $this->setMockResponse($this->client, 'Error/Error.txt');
+            $response = $this->client->getUser(['id' => '123456']);
+            $this->fail('An Exception\ClientErrorResponseException for a 404 response should have been raised');
+        }
+        catch (Exception\ClientErrorResponseException $expected) {
+            $errors = $expected->getErrors();
+            $this->assertEquals(1, count($errors));
+            $this->assertEquals('not_found', $errors[0]['code'] );
+            $this->assertEquals('No such user with id[123456]', $errors[0]['message'] );
+        }
+    }
+}

--- a/tests/Mock/Error/Error.txt
+++ b/tests/Mock/Error/Error.txt
@@ -1,0 +1,13 @@
+HTTP/1.1 404 Not Found
+Content-Type: application/json; charset=utf-8
+Date: Mon, 25 Aug 2014 23:57:54 GMT
+
+{
+  "type": "error.list",
+  "errors": [
+    {
+      "code": "not_found",
+      "message": "No such user with id[123456]"
+    }
+  ]
+}


### PR DESCRIPTION
For #37

Changes the isValidIntercomError method to be a static and adds a test case to check error data is being supplied to the Exception.
