### PR TITLE
Make user the default type for a conversations query

### DIFF
--- a/src/Intercom/Service/config/intercom_v3_conversation.json
+++ b/src/Intercom/Service/config/intercom_v3_conversation.json
@@ -103,7 +103,8 @@
                 "type": {
                     "location": "query",
                     "required": true,
-                    "static": true
+                    "static": true,
+                    "default": "user"
                 },
                 "id": {
                     "location": "query",


### PR DESCRIPTION
For #41, sets the default type to be `user`
