### PR TITLE
Tidy up service description numbering

### DIFF
--- a/src/Intercom/Service/config/intercom_v3.json
+++ b/src/Intercom/Service/config/intercom_v3.json
@@ -1,8 +1,8 @@
 {
-    "name": "Intercom API v3",
-    "apiVersion": "3.0",
+    "name": "Intercom API",
+    "apiVersion": "3",
     "baseUrl": "https://api.intercom.io/",
-    "description": "The Intercom API v3",
+    "description": "The Intercom API",
     "includes": [
         "intercom_v3_company.json",
         "intercom_v3_conversation.json",

--- a/src/Intercom/Service/config/intercom_v3_abstract_operations.json
+++ b/src/Intercom/Service/config/intercom_v3_abstract_operations.json
@@ -1,6 +1,6 @@
 {
-    "name": "Intercom API (Abstract Commands) v3",
-    "description": "The Intercom API (Abstract Commands) v3",
+    "name": "Intercom API (Abstract Commands)",
+    "description": "The Intercom API (Abstract Commands)",
     "operations": {
         "_abstract_pagination_page": {
             "httpMethod": "GET",

--- a/src/Intercom/Service/config/intercom_v3_admin.json
+++ b/src/Intercom/Service/config/intercom_v3_admin.json
@@ -1,6 +1,6 @@
 {
-    "name": "Intercom API (Admin) v3",
-    "description": "The Intercom API (Admin) v3",
+    "name": "Intercom API (Admin)",
+    "description": "The Intercom API (Admin)",
     "operations": {
         "getAdmins": {
             "httpMethod": "GET",

--- a/src/Intercom/Service/config/intercom_v3_company.json
+++ b/src/Intercom/Service/config/intercom_v3_company.json
@@ -1,6 +1,6 @@
 {
-    "name": "Intercom API (Company) v3",
-    "description": "The Intercom API (Company) v3",
+    "name": "Intercom API (Company)",
+    "description": "The Intercom API (Company)",
     "operations": {
         "getCompanies": {
             "extends": "_abstract_pagination_page",

--- a/src/Intercom/Service/config/intercom_v3_conversation.json
+++ b/src/Intercom/Service/config/intercom_v3_conversation.json
@@ -1,6 +1,6 @@
 {
-    "name": "Intercom API (Conversation) v3",
-    "description": "The Intercom API (Conversation) v3",
+    "name": "Intercom API (Conversation)",
+    "description": "The Intercom API (Conversation)",
     "operations": {
         "createMessage": {
             "httpMethod": "POST",

--- a/src/Intercom/Service/config/intercom_v3_count.json
+++ b/src/Intercom/Service/config/intercom_v3_count.json
@@ -1,6 +1,6 @@
 {
-    "name": "Intercom API (Count) v3",
-    "description": "The Intercom API (Count) v3",
+    "name": "Intercom API (Count)",
+    "description": "The Intercom API (Count)",
     "operations": {
         "getCounts": {
             "httpMethod": "GET",

--- a/src/Intercom/Service/config/intercom_v3_event.json
+++ b/src/Intercom/Service/config/intercom_v3_event.json
@@ -1,6 +1,6 @@
 {
-    "name": "Intercom API (Event) v3",
-    "description": "The Intercom API (Event) v3",
+    "name": "Intercom API (Event)",
+    "description": "The Intercom API (Event)",
     "operations": {
         "createEvent": {
             "httpMethod": "POST",

--- a/src/Intercom/Service/config/intercom_v3_note.json
+++ b/src/Intercom/Service/config/intercom_v3_note.json
@@ -1,6 +1,6 @@
 {
-    "name": "Intercom API (Note) v3",
-    "description": "The Intercom API (Note) v3",
+    "name": "Intercom API (Note)",
+    "description": "The Intercom API (Note)",
     "operations": {
         "getNotesForUser": {
             "extends": "_abstract_pagination_page",

--- a/src/Intercom/Service/config/intercom_v3_segment.json
+++ b/src/Intercom/Service/config/intercom_v3_segment.json
@@ -1,6 +1,6 @@
 {
-    "name": "Intercom API (Segment) v3",
-    "description": "The Intercom API (Segment) v3",
+    "name": "Intercom API (Segment)",
+    "description": "The Intercom API (Segment)",
     "operations": {
         "getSegments": {
             "extends": "_abstract_pagination_page",

--- a/src/Intercom/Service/config/intercom_v3_tag.json
+++ b/src/Intercom/Service/config/intercom_v3_tag.json
@@ -1,6 +1,6 @@
 {
-    "name": "Intercom API (Tag) v3",
-    "description": "The Intercom API (Tag) v3",
+    "name": "Intercom API (Tag)",
+    "description": "The Intercom API (Tag)",
     "operations": {
         "getTags": {
             "extends": "_abstract_pagination_page",

--- a/src/Intercom/Service/config/intercom_v3_user.json
+++ b/src/Intercom/Service/config/intercom_v3_user.json
@@ -1,6 +1,6 @@
 {
-    "name": "Intercom API (User) v3",
-    "description": "The Intercom API (User) v3",
+    "name": "Intercom API (User)",
+    "description": "The Intercom API (User)",
     "operations": {
         "getUser": {
             "httpMethod": "GET",


### PR DESCRIPTION
Remove 3 from the description files, but make the apiVersion '3' to keep Guzzle happy.
