### PR TITLE
Fix /events response parsing as json

### DIFF
--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -1,6 +1,10 @@
 Changes
 =========
 
+1.0.0-b4
+
+- Fix /events response being parsed as JSON
+
 1.0.0-b3
 
 - Add remote_created_at to user update and create.

--- a/src/Intercom/IntercomAbstractClient.php
+++ b/src/Intercom/IntercomAbstractClient.php
@@ -17,7 +17,7 @@ abstract class IntercomAbstractClient extends Client
     /** @var string */
     const DEFAULT_ACCEPT_HEADER = 'application/json';
 
-    const USER_AGENT = 'intercom-php/1.0.0-b2';
+    const USER_AGENT = 'intercom-php/1.0.0-b4';
 
 
     /**

--- a/src/Intercom/IntercomBasicAuthClient.php
+++ b/src/Intercom/IntercomBasicAuthClient.php
@@ -29,6 +29,8 @@ class IntercomBasicAuthClient extends IntercomAbstractClient
         $client->configure($config);
 
         $client->setBasicAuth($config->get('app_id'), $config->get('api_key'));
+        
+        $client->setUserAgent('intercom-php/1.0.0-b4', true);
 
         return $client;
     }

--- a/src/Intercom/IntercomClientTokenAuthClient.php
+++ b/src/Intercom/IntercomClientTokenAuthClient.php
@@ -30,6 +30,8 @@ class IntercomClientTokenAuthClient extends IntercomAbstractClient
         $client->configure($config);
 
         $client->setBasicAuth($config->get('client_uuid'), $config->get('client_key'));
+        
+        $client->setUserAgent('intercom-php/1.0.0-b4', true);
 
         $client->setDefaultOption('query/app_id', $config->get('app_id'));
 


### PR DESCRIPTION
Guzzle was trying to interpret a single space string as JSON, despite no content-type header being returned. Workaround to remove the space.

Guzzle was ignoring default User Agent header that was set, avoiding our workaround. Now fixed.

Fixes #48.
