### PR TITLE
Allow conversations to be fetched without a type filter

### DIFF
--- a/src/Intercom/Service/config/intercom_public_conversation.json
+++ b/src/Intercom/Service/config/intercom_public_conversation.json
@@ -97,8 +97,8 @@
             "parameters": {
                 "type": {
                     "location": "query",
-                    "required": true,
-                    "default": "user"
+                    "required": false,
+                    "type": "string"
                 },
                 "id": {
                     "location": "query",


### PR DESCRIPTION
Also corrects an issue where `type` could not be changed to `admin` (due to the `static: true` setting).

See [API Docs › List Conversations › All Conversations](http://doc.intercom.io/api/#list-conversations) for example.
