### PR TITLE
Get all conversations

### DIFF
--- a/src/Intercom/Service/config/intercom_public_conversation.json
+++ b/src/Intercom/Service/config/intercom_public_conversation.json
@@ -95,11 +95,6 @@
             "extends": "_abstract_pagination_page",
             "httpMethod": "GET",
             "parameters": {
-                "email": {
-                    "location": "query",
-                    "required": false,
-                    "type": "string"
-                },
                 "type": {
                     "location": "query",
                     "required": true,

--- a/src/Intercom/Service/config/intercom_public_conversation.json
+++ b/src/Intercom/Service/config/intercom_public_conversation.json
@@ -97,9 +97,8 @@
             "parameters": {
                 "type": {
                     "location": "query",
-                    "required": true,
-                    "static": true,
-                    "default": "user"
+                    "required": false,
+                    "type": "string"
                 },
                 "id": {
                     "location": "query",

--- a/tests/Intercom/Resources/ConversationTest.php
+++ b/tests/Intercom/Resources/ConversationTest.php
@@ -41,19 +41,37 @@ class ConversationTest extends IntercomTestCase
         $this->assertEquals(true, $response['open']);
     }
 
-    public function testGetConversations()
+    public function testGetAllConversations()
     {
         $this->setMockResponse($this->client, 'Conversation/ConversationList.txt');
         $response = $this->client->getConversations();
         $conversations = $response->get('conversations');
 
-        $this->assertRequest('GET', '/conversations?type=user');
+        $this->assertRequest('GET', '/conversations');
 
         $this->assertInstanceOf('\Guzzle\Service\Resource\Model', $response);
         $this->assertEquals(1, count($conversations));
         $this->assertEquals(1400850973, $conversations['0']['created_at']);
         $this->assertEquals('536e564f316c83104c000020', $conversations['0']['user']['id']);
         $this->assertEquals('admin', $conversations['0']['assignee']['type']);
+    }
+    
+    public function testGetUserConversations()
+    {
+        $this->setMockResponse($this->client, 'Conversation/ConversationList.txt');
+        $response = $this->client->getConversations(['type' => 'user']);
+        $conversations = $response->get('conversations');
+
+        $this->assertRequest('GET', '/conversations?type=user');
+    }
+    
+    public function testGetAdminConversations()
+    {
+        $this->setMockResponse($this->client, 'Conversation/ConversationList.txt');
+        $response = $this->client->getConversations(['type' => 'admin']);
+        $conversations = $response->get('conversations');
+
+        $this->assertRequest('GET', '/conversations?type=admin');
     }
 
     public function testReplyToConversation()


### PR DESCRIPTION
- squashed and added tests
- note that this changes the behaviour of a default GetConversations query (from user-only to all)
