### PR TITLE
Specify PHP 5.4 as minimum version in Composer

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -11,6 +11,7 @@
     ],
 
     "require": {
+        "php": ">=5.4.0",
         "guzzle/guzzle": "~3.9"
     },
 


### PR DESCRIPTION
PHP 5.3 is [no longer supported](http://php.net/supported-versions.php).
