### PR TITLE
Mark id as not required for updateUser

### DIFF
--- a/src/Intercom/Service/config/intercom_public_user.json
+++ b/src/Intercom/Service/config/intercom_public_user.json
@@ -134,7 +134,7 @@
             "parameters": {
                 "id": {
                     "location": "json",
-                    "required": true,
+                    "required": false,
                     "type": "string"
                 },
                 "companies": {


### PR DESCRIPTION
Not convinced its as easy as this, but I suppose the server will return an error if id, email and user_id are missing?