### PR TITLE
updateUser does not require ID

### DIFF
--- a/src/Intercom/Service/config/intercom_public_user.json
+++ b/src/Intercom/Service/config/intercom_public_user.json
@@ -134,7 +134,7 @@
             "parameters": {
                 "id": {
                     "location": "json",
-                    "required": true,
+                    "required": false,
                     "type": "string"
                 },
                 "companies": {

--- a/tests/Intercom/Resources/UserTest.php
+++ b/tests/Intercom/Resources/UserTest.php
@@ -118,11 +118,12 @@ class UserTest extends IntercomTestCase
         $this->assertRequest('GET', '/users?segment_id=20');
     }
 
-    /**
-     * @expectedException \Guzzle\Service\Exception\ValidationException
-     */
     public function testUpdateUserNoID()
     {
-        $this->client->updateUser();
+      $this->setMockResponse($this->client, 'User/User.txt');
+      $response = $this->client->updateUser(['user_id' => '1234', 'hi' => 'hello', 'new_session' => true]);
+      
+      $this->assertRequest('POST', '/users');
+      $this->assertRequestJson(['user_id' => '1234', 'new_session' => true]);
     }
 }


### PR DESCRIPTION
(based on https://github.com/intercom/intercom-php/pull/74, thanks @rb-cohen)
