### PR TITLE
Filter empty associative arrays to nulls when passing event metadata

### DIFF
--- a/src/Intercom/IntercomBasicAuthClient.php
+++ b/src/Intercom/IntercomBasicAuthClient.php
@@ -34,4 +34,13 @@ class IntercomBasicAuthClient extends IntercomAbstractClient
 
         return $client;
     }
+
+    public static function filterEmptyList($possiblyEmpty)
+    {
+      if (empty($possiblyEmpty)) {
+        return NULL;
+      } else {
+        return $possiblyEmpty;
+      }
+    }
 }

--- a/src/Intercom/Service/config/intercom_public_event.json
+++ b/src/Intercom/Service/config/intercom_public_event.json
@@ -24,7 +24,13 @@
                 "metadata": {
                     "location": "json",
                     "required": false,
-                    "type": "array"
+                    "type": "array",
+                    "filters": [
+                      {
+                        "method": "Intercom\\IntercomBasicAuthClient::filterEmptyList",
+                        "args": ["@value"]
+                      }
+                    ]
                 },
                 "user_id": {
                     "location": "json",

--- a/tests/Intercom/Resources/EventTest.php
+++ b/tests/Intercom/Resources/EventTest.php
@@ -13,6 +13,35 @@ class EventTest extends IntercomTestCase
         $this->assertRequestJson(['created_at' => 1401970113, 'event_name' => 'invited-friend']);
     }
 
+    /*
+     * Empty associative arrays get mapped to [] in PHP
+     * Check that we filter them out to nulls, which are valid on the server
+     */
+    public function testNoMetadata()
+    {
+        $this->setMockResponse($this->client, 'Event/Event.txt');
+        $this->client->createEvent(['metadata' => [], 'created_at' => 1401970113, 'event_name' => 'invited-friend']);
+
+        $this->assertRequest('POST', '/events');
+        $body = $this->getOnlyMockedRequest()->getBody()->__toString();
+        $json = json_decode($body);
+        $this->assertEquals(NULL, $json->metadata);
+    }
+
+    /*
+     * Check that our array filtering doesn't interfere with valid metadata
+     */
+    public function testMetadata()
+    {
+        $this->setMockResponse($this->client, 'Event/Event.txt');
+        $this->client->createEvent(['metadata' => ['foo' => 'bar'], 'created_at' => 1401970113, 'event_name' => 'invited-friend']);
+
+        $this->assertRequest('POST', '/events');
+        $body = $this->getOnlyMockedRequest()->getBody()->__toString();
+        $json = json_decode($body);
+        $this->assertEquals('bar', $json->metadata->foo);
+    }
+
     /**
      * @expectedException \Guzzle\Service\Exception\ValidationException
      */


### PR DESCRIPTION
fixes https://github.com/intercom/intercom-php/issues/87

cc @dehora 