### PR TITLE
Parse the page number from the next_page URL

### DIFF
--- a/src/Intercom/Model/Iterators/AbstractPageIterator.php
+++ b/src/Intercom/Model/Iterators/AbstractPageIterator.php
@@ -28,8 +28,14 @@ abstract class AbstractPageIterator extends ResourceIterator
         // Execute the command and parse the result
         $result = $this->command->execute();
 
-        // Parse the next token
-        $this->nextToken = (isset($result['next_page'])) ? $result['next_page'] : false;
+        if (isset($result['pages']['next'])) {
+            $url = parse_url($result['pages']['next']);
+            $out = [];
+            parse_str($url['query'], $query);
+            $this->nextToken = $query['page'];
+        } else {
+            $this->nextToken = false;
+        }
 
         // Set the total results
         $this->totalResults = $result['total_count'];


### PR DESCRIPTION
Currently the SDK is looking for...
```json
next_page: 2
```

But the actual response is
```json
"pages": {
  "next": "https://api.intercom.io/users?per_page=50&page=2",
  "page": 1,
  "per_page": 50,
  "total_pages": 3
}
```

https://doc.intercom.io/api/#list-users