### PR TITLE
Pagination fixes

### DIFF
--- a/README.md
+++ b/README.md
@@ -250,5 +250,5 @@ When listing, the Intercom API may return a pagination object:
 You can grab the next page of results using the client:
 
 ```php
-$client->nextPage($response["pages"]);
+$client->nextPage($response->pages);
 ```

--- a/src/IntercomClient.php
+++ b/src/IntercomClient.php
@@ -114,7 +114,7 @@ class IntercomClient {
 
   public function nextPage($pages)
   {
-    $response = $this->http_client->request('GET', $pages['next'], [
+    $response = $this->http_client->request('GET', $pages->next, [
       'auth' => $this->getAuth(),
       'headers' => [
         'Accept' => 'application/json'

--- a/test/IntercomClientTest.php
+++ b/test/IntercomClientTest.php
@@ -50,9 +50,10 @@ class IntercomClientTest extends PHPUnit_Framework_TestCase {
     $client = new IntercomClient('u', 'p');
     $client->setClient($http_client);
 
-    $client->nextPage([
-      'next' => 'https://foo.com'
-    ]);
+    $pages = new stdClass;
+    $pages->next = 'https://foo.com';
+
+    $client->nextPage($pages);
 
     foreach ($container as $transaction) {
       $host = $transaction['request']->getUri()->getHost();


### PR DESCRIPTION
Object of stdClass was being used as associative array, once in the README.md and once in the source code. Fixed to avoid PHP Fatal errors due to this.
