### PR TITLE
Fixing Parse error

### DIFF
--- a/src/IntercomClient.php
+++ b/src/IntercomClient.php
@@ -4,7 +4,7 @@ namespace Intercom;
 
 use GuzzleHttp\Client;
 use GuzzleHttp\Psr7\Response;
-use function GuzzleHttp\Psr7\stream_for;
+use GuzzleHttp\Psr7\stream_for;
 
 class IntercomClient {
 


### PR DESCRIPTION
function word should not be in the use statement