### PR TITLE
Fixed reading of response if it has been already read

### DIFF
--- a/src/IntercomClient.php
+++ b/src/IntercomClient.php
@@ -181,7 +181,7 @@ class IntercomClient
     private function handleResponse(Response $response)
     {
         $stream = stream_for($response->getBody());
-        $data = json_decode($stream->getContents());
+        $data = json_decode($stream);
         return $data;
     }
 }


### PR DESCRIPTION
Fixed reading of response if it has been already read by something else (like guzzle logging middleware). It happens that ->getContents() don't rewind the Stream. But __toString does: https://github.com/guzzle/psr7/blob/master/src/Stream.php#L90