### PR TITLE
FIX docblock to reflect fixed functionality

### DIFF
--- a/src/IntercomClient.php
+++ b/src/IntercomClient.php
@@ -169,7 +169,7 @@ class IntercomClient
 
     /**
      * Returns next page of the result.
-     * @param array $pages
+     * @param \stdClass $pages
      * @return mixed
      * @throws \GuzzleHttp\Exception\GuzzleException
      */


### PR DESCRIPTION
Fixes #168 in that it has already been fixed, but the docblock doesn't reflect the change. Also means the workarounds now throw errors, so patches should be reversed.