### PR TITLE
fix wrappers/adapters missing notes resource

### DIFF
--- a/src/IntercomClient.php
+++ b/src/IntercomClient.php
@@ -52,6 +52,9 @@ class IntercomClient
     /** @var IntercomBulk $bulk */
     public $bulk;
 
+    /** @var IntercomNotes $notes */
+    public $notes;
+
     /**
      * IntercomClient constructor.
      * @param string $usernamePart App ID.
@@ -72,7 +75,6 @@ class IntercomClient
         $this->counts = new IntercomCounts($this);
         $this->bulk = new IntercomBulk($this);
         $this->notes = new IntercomNotes($this);
-        $this->segments = new IntercomSegments($this);
 
         $this->usernamePart = $usernamePart;
         $this->passwordPart = $passwordPart;


### PR DESCRIPTION
fix wrappers/adapters missing notes resource and removed duplicated $segments instanciation line.

I was building an adapter for laravel 5, and noticed the public $notes resource was missing from my wrapper via '__get' because it was not explicitly declared in the Intercom/IntercomClient class definition.