### PR TITLE
Add getAdmin function for IntercomAdmins

### DIFF
--- a/src/IntercomAdmins.php
+++ b/src/IntercomAdmins.php
@@ -27,4 +27,23 @@ class IntercomAdmins {
   {
     return $this->client->get("admins", $options);
   }
+
+  /**
+   * Gets a single Admin based on the Intercom ID.
+   * @see https://developers.intercom.com/v2.0/reference#view-an-admin
+   * @param integer $id
+   * @param array $options
+   * @return mixed
+   * @throws \GuzzleHttp\Exception\GuzzleException
+   */
+  public function getAdmin($id, $options = [])
+  {
+    $path = $this->adminPath($id);
+    return $this->client->get($path, $options);
+  }
+
+  public function adminPath($id)
+  {
+    return 'admins/' . $id;
+  }
 }

--- a/test/IntercomAdminsTest.php
+++ b/test/IntercomAdminsTest.php
@@ -20,4 +20,12 @@ class IntercomAdminsTest extends PHPUnit_Framework_TestCase {
     $users = new IntercomAdmins($stub);
     $this->assertEquals('foo', $users->getAdmin(1));
   }
+
+  public function testAdminsGetPath()
+   {
+     $stub = $this->getMockBuilder('Intercom\IntercomClient')->disableOriginalConstructor()->getMock();
+
+     $users = new IntercomAdmins($stub);
+     $this->assertEquals('admins/1', $users->adminPath(1));
+   }
 }

--- a/test/IntercomAdminsTest.php
+++ b/test/IntercomAdminsTest.php
@@ -22,10 +22,10 @@ class IntercomAdminsTest extends PHPUnit_Framework_TestCase {
   }
 
   public function testAdminsGetPath()
-   {
-     $stub = $this->getMockBuilder('Intercom\IntercomClient')->disableOriginalConstructor()->getMock();
+  {
+    $stub = $this->getMockBuilder('Intercom\IntercomClient')->disableOriginalConstructor()->getMock();
 
-     $users = new IntercomAdmins($stub);
-     $this->assertEquals('admins/1', $users->adminPath(1));
-   }
+    $users = new IntercomAdmins($stub);
+    $this->assertEquals('admins/1', $users->adminPath(1));
+  }
 }

--- a/test/IntercomAdminsTest.php
+++ b/test/IntercomAdminsTest.php
@@ -11,4 +11,13 @@ class IntercomAdminsTest extends PHPUnit_Framework_TestCase {
     $users = new IntercomAdmins($stub);
     $this->assertEquals('foo', $users->getAdmins());
   }
+
+  public function testAdminsGet()
+  {
+    $stub = $this->getMockBuilder('Intercom\IntercomClient')->disableOriginalConstructor()->getMock();
+    $stub->method('get')->willReturn('foo');
+
+    $users = new IntercomAdmins($stub);
+    $this->assertEquals('foo', $users->getAdmin(1));
+  }
 }


### PR DESCRIPTION
We needed to have a quick way to get information about a specific admin, without having to get all the admins and cycle over them to get one name, also preventing us from starting having to use pagination.