### PR TITLE
Avoid 'use function' to ensure compatibility with PHP5.6

### DIFF
--- a/src/IntercomClient.php
+++ b/src/IntercomClient.php
@@ -4,7 +4,6 @@ namespace Intercom;
 
 use GuzzleHttp\Client;
 use GuzzleHttp\Psr7\Response;
-use function GuzzleHttp\Psr7\stream_for;
 use Psr\Http\Message\ResponseInterface;
 
 class IntercomClient
@@ -207,7 +206,7 @@ class IntercomClient
     {
         $this->setRateLimitDetails($response);
 
-        $stream = stream_for($response->getBody());
+        $stream = \GuzzleHttp\Psr7\stream_for($response->getBody());
         $data = json_decode($stream);
         return $data;
     }


### PR DESCRIPTION
We have Symfony 2.7 with PHP 5.6.31 and "use function" yell some errors. So we have to add this to avoid the error.