### PR TITLE
Fixed whitespace, indenting and commenting inconsistencies

### DIFF
--- a/src/IntercomAdmins.php
+++ b/src/IntercomAdmins.php
@@ -5,46 +5,51 @@ namespace Intercom;
 class IntercomAdmins
 {
 
-  /** @var IntercomClient */
-  private $client;
+    /**
+     * @var IntercomClient 
+     */
+    private $client;
 
-  /**
-   * IntercomAdmins constructor.
-   * @param IntercomClient $client
-   */
-  public function __construct($client)
-  {
-      $this->client = $client;
-  }
+    /**
+     * IntercomAdmins constructor.
+     *
+     * @param IntercomClient $client
+     */
+    public function __construct($client)
+    {
+        $this->client = $client;
+    }
 
-  /**
-   * Returns list of Admins.
-   * @see https://developers.intercom.io/reference#list-admins
-   * @param array $options
-   * @return mixed
-   * @throws \GuzzleHttp\Exception\GuzzleException
-   */
-  public function getAdmins($options = [])
-  {
-      return $this->client->get("admins", $options);
-  }
+    /**
+     * Returns list of Admins.
+     *
+     * @see    https://developers.intercom.io/reference#list-admins
+     * @param  array $options
+     * @return mixed
+     * @throws \GuzzleHttp\Exception\GuzzleException
+     */
+    public function getAdmins($options = [])
+    {
+        return $this->client->get("admins", $options);
+    }
 
-  /**
-   * Gets a single Admin based on the Intercom ID.
-   * @see https://developers.intercom.com/v2.0/reference#view-an-admin
-   * @param integer $id
-   * @param array $options
-   * @return mixed
-   * @throws \GuzzleHttp\Exception\GuzzleException
-   */
-  public function getAdmin($id, $options = [])
-  {
-    $path = $this->adminPath($id);
-    return $this->client->get($path, $options);
-  }
+    /**
+     * Gets a single Admin based on the Intercom ID.
+     *
+     * @see    https://developers.intercom.com/v2.0/reference#view-an-admin
+     * @param  integer $id
+     * @param  array   $options
+     * @return mixed
+     * @throws \GuzzleHttp\Exception\GuzzleException
+     */
+    public function getAdmin($id, $options = [])
+    {
+        $path = $this->adminPath($id);
+        return $this->client->get($path, $options);
+    }
 
-  public function adminPath($id)
-  {
-    return 'admins/' . $id;
-  }
+    public function adminPath($id)
+    {
+        return 'admins/' . $id;
+    }
 }

--- a/src/IntercomBulk.php
+++ b/src/IntercomBulk.php
@@ -5,39 +5,44 @@ namespace Intercom;
 class IntercomBulk
 {
 
-  /** @var IntercomClient */
-  private $client;
+    /**
+     * @var IntercomClient 
+     */
+    private $client;
 
-  /**
-   * IntercomBulk constructor.
-   * @param IntercomClient $client
-   */
-  public function __construct($client)
-  {
-      $this->client = $client;
-  }
+    /**
+     * IntercomBulk constructor.
+     *
+     * @param IntercomClient $client
+     */
+    public function __construct($client)
+    {
+        $this->client = $client;
+    }
 
-  /**
-   * Creates Users in bulk.
-   * @see https://developers.intercom.io/reference#bulk-user-operations
-   * @param array $options
-   * @return mixed
-   * @throws \GuzzleHttp\Exception\GuzzleException
-   */
-  public function users($options)
-  {
-      return $this->client->post("bulk/users", $options);
-  }
+    /**
+     * Creates Users in bulk.
+     *
+     * @see    https://developers.intercom.io/reference#bulk-user-operations
+     * @param  array $options
+     * @return mixed
+     * @throws \GuzzleHttp\Exception\GuzzleException
+     */
+    public function users($options)
+    {
+        return $this->client->post("bulk/users", $options);
+    }
 
-  /**
-   * Creates Events in bulk.
-   * @see https://developers.intercom.io/reference#bulk-event-operations
-   * @param array $options
-   * @return mixed
-   * @throws \GuzzleHttp\Exception\GuzzleException
-   */
-  public function events($options)
-  {
-      return $this->client->post("bulk/events", $options);
-  }
+    /**
+     * Creates Events in bulk.
+     *
+     * @see    https://developers.intercom.io/reference#bulk-event-operations
+     * @param  array $options
+     * @return mixed
+     * @throws \GuzzleHttp\Exception\GuzzleException
+     */
+    public function events($options)
+    {
+        return $this->client->post("bulk/events", $options);
+    }
 }

--- a/src/IntercomClient.php
+++ b/src/IntercomClient.php
@@ -9,59 +9,94 @@ use Psr\Http\Message\ResponseInterface;
 class IntercomClient
 {
 
-    /** @var Client $http_client */
+    /**
+     * @var Client $http_client 
+     */
     private $http_client;
 
-    /** @var string API user authentication */
+    /**
+     * @var string API user authentication 
+     */
     protected $usernamePart;
 
-    /** @var string API password authentication */
+    /**
+     * @var string API password authentication 
+     */
     protected $passwordPart;
 
-    /** @var string Extra Guzzle Requests Options */
+    /**
+     * @var string Extra Guzzle Requests Options 
+     */
     protected $extraGuzzleRequestsOptions;
 
-    /** @var IntercomUsers $users */
+    /**
+     * @var IntercomUsers $users 
+     */
     public $users;
 
-    /** @var IntercomEvents $events */
+    /**
+     * @var IntercomEvents $events 
+     */
     public $events;
 
-    /** @var IntercomCompanies $companies */
+    /**
+     * @var IntercomCompanies $companies 
+     */
     public $companies;
 
-    /** @var IntercomMessages $messages */
+    /**
+     * @var IntercomMessages $messages 
+     */
     public $messages;
 
-    /** @var IntercomConversations $conversations */
+    /**
+     * @var IntercomConversations $conversations 
+     */
     public $conversations;
 
-    /** @var IntercomLeads $leads */
+    /**
+     * @var IntercomLeads $leads 
+     */
     public $leads;
 
-    /** @var IntercomAdmins $admins */
+    /**
+     * @var IntercomAdmins $admins 
+     */
     public $admins;
 
-    /** @var IntercomTags $tags */
+    /**
+     * @var IntercomTags $tags 
+     */
     public $tags;
 
-    /** @var IntercomSegments $segments */
+    /**
+     * @var IntercomSegments $segments 
+     */
     public $segments;
 
-    /** @var IntercomCounts $counts */
+    /**
+     * @var IntercomCounts $counts 
+     */
     public $counts;
 
-    /** @var IntercomBulk $bulk */
+    /**
+     * @var IntercomBulk $bulk 
+     */
     public $bulk;
 
-    /** @var IntercomNotes $notes */
+    /**
+     * @var IntercomNotes $notes 
+     */
     public $notes;
 
-    /** @var int[] $rateLimitDetails */
+    /**
+     * @var int[] $rateLimitDetails 
+     */
     protected $rateLimitDetails = [];
 
     /**
      * IntercomClient constructor.
+     *
      * @param string $usernamePart App ID.
      * @param string $passwordPart Api Key.
      */
@@ -94,6 +129,7 @@ class IntercomClient
 
     /**
      * Sets GuzzleHttp client.
+     *
      * @param Client $client
      */
     public function setClient($client)
@@ -103,40 +139,46 @@ class IntercomClient
 
     /**
      * Sends POST request to Intercom API.
-     * @param string $endpoint
-     * @param string $json
+     *
+     * @param  string $endpoint
+     * @param  string $json
      * @return mixed
      * @throws \GuzzleHttp\Exception\GuzzleException
      */
     public function post($endpoint, $json)
     {
-        $guzzleRequestOptions = $this->getGuzzleRequestOptions([
+        $guzzleRequestOptions = $this->getGuzzleRequestOptions(
+            [
             'json' => $json,
             'auth' => $this->getAuth(),
             'headers' => [
                 'Accept' => 'application/json'
             ],
-        ]);
+            ]
+        );
         $response = $this->http_client->request('POST', "https://api.intercom.io/$endpoint", $guzzleRequestOptions);
         return $this->handleResponse($response);
     }
 
     /**
      * Sends PUT request to Intercom API.
-     * @param string $endpoint
-     * @param string $json
+     *
+     * @param  string $endpoint
+     * @param  string $json
      * @return mixed
      * @throws \GuzzleHttp\Exception\GuzzleException
      */
     public function put($endpoint, $json)
     {
-        $guzzleRequestOptions = $this->getGuzzleRequestOptions([
+        $guzzleRequestOptions = $this->getGuzzleRequestOptions(
+            [
             'json' => $json,
             'auth' => $this->getAuth(),
             'headers' => [
                 'Accept' => 'application/json'
             ],
-        ]);
+            ]
+        );
 
         $response = $this->http_client->request('PUT', "https://api.intercom.io/$endpoint", $guzzleRequestOptions);
         return $this->handleResponse($response);
@@ -144,20 +186,23 @@ class IntercomClient
 
     /**
      * Sends DELETE request to Intercom API.
-     * @param string $endpoint
-     * @param string $json
+     *
+     * @param  string $endpoint
+     * @param  string $json
      * @return mixed
      * @throws \GuzzleHttp\Exception\GuzzleException
      */
     public function delete($endpoint, $json)
     {
-        $guzzleRequestOptions = $this->getGuzzleRequestOptions([
+        $guzzleRequestOptions = $this->getGuzzleRequestOptions(
+            [
             'json' => $json,
             'auth' => $this->getAuth(),
             'headers' => [
                 'Accept' => 'application/json'
             ],
-        ]);
+            ]
+        );
 
         $response = $this->http_client->request('DELETE', "https://api.intercom.io/$endpoint", $guzzleRequestOptions);
         return $this->handleResponse($response);
@@ -165,19 +210,21 @@ class IntercomClient
 
     /**
      * @param string $endpoint
-     * @param array $query
+     * @param array  $query
      * @return mixed
      * @throws \GuzzleHttp\Exception\GuzzleException
      */
     public function get($endpoint, $query)
     {
-        $guzzleRequestOptions = $this->getGuzzleRequestOptions([
+        $guzzleRequestOptions = $this->getGuzzleRequestOptions(
+            [
             'query' => $query,
             'auth' => $this->getAuth(),
             'headers' => [
                 'Accept' => 'application/json'
             ],
-        ]);
+            ]
+        );
 
         $response = $this->http_client->request('GET', "https://api.intercom.io/$endpoint", $guzzleRequestOptions);
         return $this->handleResponse($response);
@@ -185,18 +232,21 @@ class IntercomClient
 
     /**
      * Returns next page of the result.
-     * @param \stdClass $pages
+     *
+     * @param  \stdClass $pages
      * @return mixed
      * @throws \GuzzleHttp\Exception\GuzzleException
      */
     public function nextPage($pages)
     {
-        $guzzleRequestOptions = $this->getGuzzleRequestOptions([
+        $guzzleRequestOptions = $this->getGuzzleRequestOptions(
+            [
             'auth' => $this->getAuth(),
             'headers' => [
                 'Accept' => 'application/json'
             ],
-        ]);
+            ]
+        );
 
         $response = $this->http_client->request('GET', $pages->next, $guzzleRequestOptions);
         return $this->handleResponse($response);
@@ -204,6 +254,7 @@ class IntercomClient
 
     /**
      * Returns Guzzle Requests Options Array
+     *
      * @param  array $defaultGuzzleRequestsOptions
      * @return array
      */
@@ -214,6 +265,7 @@ class IntercomClient
 
     /**
      * Returns authentication parameters.
+     *
      * @return array
      */
     public function getAuth()

--- a/src/IntercomCompanies.php
+++ b/src/IntercomCompanies.php
@@ -5,51 +5,57 @@ namespace Intercom;
 class IntercomCompanies
 {
 
-  /** @var IntercomClient */
-  private $client;
+    /**
+     * @var IntercomClient 
+     */
+    private $client;
 
-  /**
-   * IntercomCompanies constructor.
-   * @param IntercomClient $client
-   */
-  public function __construct($client)
-  {
-      $this->client = $client;
-  }
+    /**
+     * IntercomCompanies constructor.
+     *
+     * @param IntercomClient $client
+     */
+    public function __construct($client)
+    {
+        $this->client = $client;
+    }
 
-  /**
-   * Creates a Company.
-   * @see https://developers.intercom.io/reference#create-or-update-company
-   * @param array $options
-   * @return mixed
-   * @throws \GuzzleHttp\Exception\GuzzleException
-   */
-  public function create($options)
-  {
-      return $this->client->post("companies", $options);
-  }
+    /**
+     * Creates a Company.
+     *
+     * @see    https://developers.intercom.io/reference#create-or-update-company
+     * @param  array $options
+     * @return mixed
+     * @throws \GuzzleHttp\Exception\GuzzleException
+     */
+    public function create($options)
+    {
+        return $this->client->post("companies", $options);
+    }
 
-  /**
-   * Updates a Company.
-   * @see https://developers.intercom.io/reference#create-or-update-company
-   * @param array $options
-   * @return mixed
-   * @throws \GuzzleHttp\Exception\GuzzleException
-   */
-  public function update($options)
-  {
-      return $this->create($options);
-  }
+    /**
+     * Updates a Company.
+     *
+     * @see    https://developers.intercom.io/reference#create-or-update-company
+     * @param  array $options
+     * @return mixed
+     * @throws \GuzzleHttp\Exception\GuzzleException
+     */
+    public function update($options)
+    {
+        return $this->create($options);
+    }
 
-  /**
-   * Returns list of Companies.
-   * @see https://developers.intercom.io/reference#list-companies
-   * @param array $options
-   * @return mixed
-   * @throws \GuzzleHttp\Exception\GuzzleException
-   */
-  public function getCompanies($options)
-  {
-      return $this->client->get("companies", $options);
-  }
+    /**
+     * Returns list of Companies.
+     *
+     * @see    https://developers.intercom.io/reference#list-companies
+     * @param  array $options
+     * @return mixed
+     * @throws \GuzzleHttp\Exception\GuzzleException
+     */
+    public function getCompanies($options)
+    {
+        return $this->client->get("companies", $options);
+    }
 }

--- a/src/IntercomConversations.php
+++ b/src/IntercomConversations.php
@@ -5,101 +5,111 @@ namespace Intercom;
 class IntercomConversations
 {
 
-  /** @var IntercomClient  */
-  private $client;
+    /**
+     * @var IntercomClient  
+     */
+    private $client;
 
-  /**
-   * IntercomConversations constructor.
-   * @param IntercomClient $client
-   */
-  public function __construct($client)
-  {
-      $this->client = $client;
-  }
+    /**
+     * IntercomConversations constructor.
+     *
+     * @param IntercomClient $client
+     */
+    public function __construct($client)
+    {
+        $this->client = $client;
+    }
 
-  /**
-   * Returns list of Conversations.
-   * @see https://developers.intercom.io/reference#list-conversations
-   * @param array $options
-   * @return mixed
-   * @throws \GuzzleHttp\Exception\GuzzleException
-   */
-  public function getConversations($options)
-  {
-      return $this->client->get('conversations', $options);
-  }
+    /**
+     * Returns list of Conversations.
+     *
+     * @see    https://developers.intercom.io/reference#list-conversations
+     * @param  array $options
+     * @return mixed
+     * @throws \GuzzleHttp\Exception\GuzzleException
+     */
+    public function getConversations($options)
+    {
+        return $this->client->get('conversations', $options);
+    }
 
-  /**
-   * Returns single Conversation.
-   * @see https://developers.intercom.io/reference#get-a-single-conversation
-   * @param string $id
-   * @return mixed
-   * @throws \GuzzleHttp\Exception\GuzzleException
-   */
-  public function getConversation($id, $options = [])
-  {
-      $path = $this->conversationPath($id);
-      return $this->client->get($path, $options);
-  }
+    /**
+     * Returns single Conversation.
+     *
+     * @see    https://developers.intercom.io/reference#get-a-single-conversation
+     * @param  string $id
+     * @return mixed
+     * @throws \GuzzleHttp\Exception\GuzzleException
+     */
+    public function getConversation($id, $options = [])
+    {
+        $path = $this->conversationPath($id);
+        return $this->client->get($path, $options);
+    }
 
-  /**
-   * Creates Conversation Reply to Conversation with given ID.
-   * @see https://developers.intercom.io/reference#replying-to-a-conversation
-   * @param string $id
-   * @param array $options
-   * @return mixed
-   * @throws \GuzzleHttp\Exception\GuzzleException
-   */
-  public function replyToConversation($id, $options)
-  {
-      $path = $this->conversationReplyPath($id);
-      return $this->client->post($path, $options);
-  }
+    /**
+     * Creates Conversation Reply to Conversation with given ID.
+     *
+     * @see    https://developers.intercom.io/reference#replying-to-a-conversation
+     * @param  string $id
+     * @param  array  $options
+     * @return mixed
+     * @throws \GuzzleHttp\Exception\GuzzleException
+     */
+    public function replyToConversation($id, $options)
+    {
+        $path = $this->conversationReplyPath($id);
+        return $this->client->post($path, $options);
+    }
 
-   /**
-   * Creates Conversation Reply to last conversation. (no need to specify Conversation ID.)
-   * @see https://developers.intercom.io/reference#replying-to-users-last-conversation
-   * @param array $options
-   * @return mixed
-   * @throws \GuzzleHttp\Exception\GuzzleException
-   */
-  public function replyToLastConversation($options)
-  {
-      $path = 'conversations/last/reply';
-      return $this->client->post($path, $options);
-  }
+    /**
+     * Creates Conversation Reply to last conversation. (no need to specify Conversation ID.)
+     *
+     * @see    https://developers.intercom.io/reference#replying-to-users-last-conversation
+     * @param  array $options
+     * @return mixed
+     * @throws \GuzzleHttp\Exception\GuzzleException
+     */
+    public function replyToLastConversation($options)
+    {
+        $path = 'conversations/last/reply';
+        return $this->client->post($path, $options);
+    }
 
-   /**
-   * Marks a Conversation as read based on the given Conversation ID.
-   * @see https://developers.intercom.io/reference#marking-a-conversation-as-read
-   * @param string $id
-   * @return mixed
-   * @throws \GuzzleHttp\Exception\GuzzleException
-   */
-  public function markConversationAsRead($id)
-  {
-      $path = $this->conversationPath($id);
-      $data = ['read' => true];
-      return $this->client->put($path, $data);
-  }
+    /**
+     * Marks a Conversation as read based on the given Conversation ID.
+     *
+     * @see    https://developers.intercom.io/reference#marking-a-conversation-as-read
+     * @param  string $id
+     * @return mixed
+     * @throws \GuzzleHttp\Exception\GuzzleException
+     */
+    public function markConversationAsRead($id)
+    {
+        $path = $this->conversationPath($id);
+        $data = ['read' => true];
+        return $this->client->put($path, $data);
+    }
 
-  /**
-   * Returns endpoint path to Conversation with given ID.
-   * @param string $id
-   * @return string
-   */
-  public function conversationPath($id)
-  {
-      return 'conversations/' . $id;
-  }
+    /**
+     * Returns endpoint path to Conversation with given ID.
+     *
+     * @param  string $id
+     * @return string
+     */
+    public function conversationPath($id)
+    {
+        return 'conversations/' . $id;
+    }
 
-  /**
-   * Returns endpoint path to Conversation Reply for Conversation with given ID.
-   * @param string $id
-   * @return string
-   */
-  public function conversationReplyPath($id)
-  {
-      return 'conversations/' . $id . '/reply';
-  }
+    /**
+     * Returns endpoint path to Conversation Reply for Conversation with given ID.
+     *
+     * @param  string $id
+     * @return string
+     */
+    public function conversationReplyPath($id)
+    {
+        return 'conversations/' . $id . '/reply';
+    }
 }

--- a/src/IntercomCounts.php
+++ b/src/IntercomCounts.php
@@ -5,27 +5,31 @@ namespace Intercom;
 class IntercomCounts
 {
 
-  /** @var IntercomClient */
-  private $client;
+    /**
+     * @var IntercomClient 
+     */
+    private $client;
 
-  /**
-   * IntercomCounts constructor.
-   * @param IntercomClient $client
-   */
-  public function __construct($client)
-  {
-      $this->client = $client;
-  }
+    /**
+     * IntercomCounts constructor.
+     *
+     * @param IntercomClient $client
+     */
+    public function __construct($client)
+    {
+        $this->client = $client;
+    }
 
-  /**
-   * Returns list of Counts.
-   * @see https://developers.intercom.io/reference#getting-counts
-   * @param array $options
-   * @return mixed
-   * @throws \GuzzleHttp\Exception\GuzzleException
-   */
-  public function getCounts($options = [])
-  {
-      return $this->client->get("counts", $options);
-  }
+    /**
+     * Returns list of Counts.
+     *
+     * @see    https://developers.intercom.io/reference#getting-counts
+     * @param  array $options
+     * @return mixed
+     * @throws \GuzzleHttp\Exception\GuzzleException
+     */
+    public function getCounts($options = [])
+    {
+        return $this->client->get("counts", $options);
+    }
 }

--- a/src/IntercomEvents.php
+++ b/src/IntercomEvents.php
@@ -5,39 +5,44 @@ namespace Intercom;
 class IntercomEvents
 {
 
-  /** @var IntercomClient */
-  private $client;
+    /**
+     * @var IntercomClient 
+     */
+    private $client;
 
-  /**
-   * IntercomEvents constructor.
-   * @param IntercomClient $client
-   */
-  public function __construct($client)
-  {
-      $this->client = $client;
-  }
+    /**
+     * IntercomEvents constructor.
+     *
+     * @param IntercomClient $client
+     */
+    public function __construct($client)
+    {
+        $this->client = $client;
+    }
 
-  /**
-   * Creates Event.
-   * @see https://developers.intercom.io/reference#submitting-events
-   * @param array $options
-   * @return mixed
-   * @throws \GuzzleHttp\Exception\GuzzleException
-   */
-  public function create($options)
-  {
-      return $this->client->post("events", $options);
-  }
+    /**
+     * Creates Event.
+     *
+     * @see    https://developers.intercom.io/reference#submitting-events
+     * @param  array $options
+     * @return mixed
+     * @throws \GuzzleHttp\Exception\GuzzleException
+     */
+    public function create($options)
+    {
+        return $this->client->post("events", $options);
+    }
 
-  /**
-   * Lists User Events.
-   * @see https://developers.intercom.io/reference#list-user-events
-   * @param array $options
-   * @return mixed
-   * @throws \GuzzleHttp\Exception\GuzzleException
-   */
-  public function getEvents($options)
-  {
-      return $this->client->get("events", array_merge(["type" => "user"], $options));
-  }
+    /**
+     * Lists User Events.
+     *
+     * @see    https://developers.intercom.io/reference#list-user-events
+     * @param  array $options
+     * @return mixed
+     * @throws \GuzzleHttp\Exception\GuzzleException
+     */
+    public function getEvents($options)
+    {
+        return $this->client->get("events", array_merge(["type" => "user"], $options));
+    }
 }

--- a/src/IntercomLeads.php
+++ b/src/IntercomLeads.php
@@ -5,101 +5,111 @@ namespace Intercom;
 class IntercomLeads
 {
 
-  /** @var IntercomClient */
-  private $client;
+    /**
+     * @var IntercomClient 
+     */
+    private $client;
 
-  /**
-   * IntercomLeads constructor.
-   * @param IntercomClient $client
-   */
-  public function __construct($client)
-  {
-      $this->client = $client;
-  }
+    /**
+     * IntercomLeads constructor.
+     *
+     * @param IntercomClient $client
+     */
+    public function __construct($client)
+    {
+        $this->client = $client;
+    }
 
-  /**
-   * Creates Lead.
-   * @see https://developers.intercom.io/reference#create-lead
-   * @param array $options
-   * @return mixed
-   * @throws \GuzzleHttp\Exception\GuzzleException
-   */
-  public function create($options)
-  {
-      return $this->client->post("contacts", $options);
-  }
+    /**
+     * Creates Lead.
+     *
+     * @see    https://developers.intercom.io/reference#create-lead
+     * @param  array $options
+     * @return mixed
+     * @throws \GuzzleHttp\Exception\GuzzleException
+     */
+    public function create($options)
+    {
+        return $this->client->post("contacts", $options);
+    }
 
-  /**
-   * Creates Lead.
-   * @see https://developers.intercom.io/reference#create-lead
-   * @param array $options
-   * @return mixed
-   * @throws \GuzzleHttp\Exception\GuzzleException
-   */
-  public function update($options)
-  {
-      return $this->create($options);
-  }
+    /**
+     * Creates Lead.
+     *
+     * @see    https://developers.intercom.io/reference#create-lead
+     * @param  array $options
+     * @return mixed
+     * @throws \GuzzleHttp\Exception\GuzzleException
+     */
+    public function update($options)
+    {
+        return $this->create($options);
+    }
 
-  /**
-   * Lists Leads.
-   * @see https://developers.intercom.io/reference#list-leads
-   * @param array $options
-   * @return mixed
-   * @throws \GuzzleHttp\Exception\GuzzleException
-   */
-  public function getLeads($options)
-  {
-      return $this->client->get("contacts", $options);
-  }
+    /**
+     * Lists Leads.
+     *
+     * @see    https://developers.intercom.io/reference#list-leads
+     * @param  array $options
+     * @return mixed
+     * @throws \GuzzleHttp\Exception\GuzzleException
+     */
+    public function getLeads($options)
+    {
+        return $this->client->get("contacts", $options);
+    }
 
-  /**
-   * Returns single Lead.
-   * @see https://developers.intercom.io/reference#view-a-lead
-   * @param string $id
-   * @param array $options
-   * @return mixed
-   * @throws \GuzzleHttp\Exception\GuzzleException
-   */
-  public function getLead($id, $options = [])
-  {
-      $path = $this->leadPath($id);
-      return $this->client->get($path, $options);
-  }
+    /**
+     * Returns single Lead.
+     *
+     * @see    https://developers.intercom.io/reference#view-a-lead
+     * @param  string $id
+     * @param  array  $options
+     * @return mixed
+     * @throws \GuzzleHttp\Exception\GuzzleException
+     */
+    public function getLead($id, $options = [])
+    {
+        $path = $this->leadPath($id);
+        return $this->client->get($path, $options);
+    }
 
-  /**
-   * Deletes Lead.
-   * @see https://developers.intercom.io/reference#delete-a-lead
-   * @param string $id
-   * @param array $options
-   * @return mixed
-   * @throws \GuzzleHttp\Exception\GuzzleException
-   */
-  public function deleteLead($id, $options = [])
-  {
-      $path = $this->leadPath($id);
-      return $this->client->delete($path, $options);
-  }
+    /**
+     * Deletes Lead.
+     *
+     * @see    https://developers.intercom.io/reference#delete-a-lead
+     * @param  string $id
+     * @param  array  $options
+     * @return mixed
+     * @throws \GuzzleHttp\Exception\GuzzleException
+     */
+    public function deleteLead($id, $options = [])
+    {
+        $path = $this->leadPath($id);
+        return $this->client->delete($path, $options);
+    }
 
-  /**
-   * Converts Lead.
-   * @see https://developers.intercom.io/reference#convert-a-lead
-   * @param $options
-   * @return mixed
-   * @throws \GuzzleHttp\Exception\GuzzleException
-   */
-  public function convertLead($options)
-  {
-      return $this->client->post("contacts/convert", $options);
-  }
+    /**
+     * Converts Lead.
+     *
+     * @see    https://developers.intercom.io/reference#convert-a-lead
+     * @param  $options
+     * @return mixed
+     * @throws \GuzzleHttp\Exception\GuzzleException
+     */
+    public function convertLead($options)
+    {
+        return $this->client->post("contacts/convert", $options);
+    }
 
-  /**
-   * Returns endpoint path to Lead with given ID.
-   * @param string $id
-   * @return string
-   */
-  public function leadPath($id)
-  {
-      return "contacts/" . $id;
-  }
+    /**
+     * Returns endpoint path to Lead with given ID.
+     *
+     * @param  string $id
+     * @return string
+     */
+    public function leadPath($id)
+    {
+        return "contacts/" . $id;
+    }
 }

--- a/src/IntercomMessages.php
+++ b/src/IntercomMessages.php
@@ -5,27 +5,31 @@ namespace Intercom;
 class IntercomMessages
 {
 
-  /** @var IntercomClient */
-  private $client;
+    /**
+     * @var IntercomClient 
+     */
+    private $client;
 
-  /**
-   * IntercomMessages constructor.
-   * @param IntercomClient $client
-   */
-  public function __construct($client)
-  {
-      $this->client = $client;
-  }
+    /**
+     * IntercomMessages constructor.
+     *
+     * @param IntercomClient $client
+     */
+    public function __construct($client)
+    {
+        $this->client = $client;
+    }
 
-  /**
-   * Creates Message.
-   * @see https://developers.intercom.io/reference#conversations
-   * @param array $options
-   * @return mixed
-   * @throws \GuzzleHttp\Exception\GuzzleException
-   */
-  public function create($options)
-  {
-      return $this->client->post("messages", $options);
-  }
+    /**
+     * Creates Message.
+     *
+     * @see    https://developers.intercom.io/reference#conversations
+     * @param  array $options
+     * @return mixed
+     * @throws \GuzzleHttp\Exception\GuzzleException
+     */
+    public function create($options)
+    {
+        return $this->client->post("messages", $options);
+    }
 }

--- a/src/IntercomNotes.php
+++ b/src/IntercomNotes.php
@@ -5,51 +5,57 @@ namespace Intercom;
 class IntercomNotes
 {
 
-  /** @var IntercomClient */
-  private $client;
+    /**
+     * @var IntercomClient 
+     */
+    private $client;
 
-  /**
-   * IntercomNotes constructor.
-   * @param IntercomClient $client
-   */
-  public function __construct($client)
-  {
-      $this->client = $client;
-  }
+    /**
+     * IntercomNotes constructor.
+     *
+     * @param IntercomClient $client
+     */
+    public function __construct($client)
+    {
+        $this->client = $client;
+    }
 
-  /**
-   * Creates Note.
-   * @see https://developers.intercom.io/reference#create-a-note
-   * @param array $options
-   * @return mixed
-   * @throws \GuzzleHttp\Exception\GuzzleException
-   */
-  public function create($options)
-  {
-      return $this->client->post("notes", $options);
-  }
+    /**
+     * Creates Note.
+     *
+     * @see    https://developers.intercom.io/reference#create-a-note
+     * @param  array $options
+     * @return mixed
+     * @throws \GuzzleHttp\Exception\GuzzleException
+     */
+    public function create($options)
+    {
+        return $this->client->post("notes", $options);
+    }
 
-  /**
-   * Lists Notes.
-   * @see https://developers.intercom.io/reference#list-notes-for-a-user
-   * @param array $options
-   * @return mixed
-   * @throws \GuzzleHttp\Exception\GuzzleException
-   */
-  public function getNotes($options)
-  {
-      return $this->client->get("notes", $options);
-  }
+    /**
+     * Lists Notes.
+     *
+     * @see    https://developers.intercom.io/reference#list-notes-for-a-user
+     * @param  array $options
+     * @return mixed
+     * @throws \GuzzleHttp\Exception\GuzzleException
+     */
+    public function getNotes($options)
+    {
+        return $this->client->get("notes", $options);
+    }
 
-  /**
-   * Returns single Note.
-   * @see https://developers.intercom.io/reference#view-a-note
-   * @param string $id
-   * @return mixed
-   * @throws \GuzzleHttp\Exception\GuzzleException
-   */
-  public function getNote($id)
-  {
-      return $this->client->get("notes/" . $id, []);
-  }
+    /**
+     * Returns single Note.
+     *
+     * @see    https://developers.intercom.io/reference#view-a-note
+     * @param  string $id
+     * @return mixed
+     * @throws \GuzzleHttp\Exception\GuzzleException
+     */
+    public function getNote($id)
+    {
+        return $this->client->get("notes/" . $id, []);
+    }
 }

--- a/src/IntercomSegments.php
+++ b/src/IntercomSegments.php
@@ -5,40 +5,45 @@ namespace Intercom;
 class IntercomSegments
 {
 
-  /** @var IntercomClient */
-  private $client;
+    /**
+     * @var IntercomClient 
+     */
+    private $client;
 
-  /**
-   * IntercomTags constructor.
-   * @param IntercomClient $client
-   */
-  public function __construct($client)
-  {
-      $this->client = $client;
-  }
+    /**
+     * IntercomTags constructor.
+     *
+     * @param IntercomClient $client
+     */
+    public function __construct($client)
+    {
+        $this->client = $client;
+    }
 
-  /**
-   * Gets a single segment by ID.
-   * @see https://developers.intercom.com/reference#view-a-segment
-   * @param string $id
-   * @param array $options
-   * @return mixed
-   * @throws \GuzzleHttp\Exception\GuzzleException
-   */
-  public function getSegment($id, array $options = [])
-  {
-      return $this->client->get('segments/' . $id, $options);
-  }
+    /**
+     * Gets a single segment by ID.
+     *
+     * @see    https://developers.intercom.com/reference#view-a-segment
+     * @param  string $id
+     * @param  array  $options
+     * @return mixed
+     * @throws \GuzzleHttp\Exception\GuzzleException
+     */
+    public function getSegment($id, array $options = [])
+    {
+        return $this->client->get('segments/' . $id, $options);
+    }
 
-  /**
-   * Lists Segments.
-   * @see https://developers.intercom.com/reference#list-segments
-   * @param array $options
-   * @return mixed
-   * @throws \GuzzleHttp\Exception\GuzzleException
-   */
-  public function getSegments($options = [])
-  {
-      return $this->client->get("segments", $options);
-  }
+    /**
+     * Lists Segments.
+     *
+     * @see    https://developers.intercom.com/reference#list-segments
+     * @param  array $options
+     * @return mixed
+     * @throws \GuzzleHttp\Exception\GuzzleException
+     */
+    public function getSegments($options = [])
+    {
+        return $this->client->get("segments", $options);
+    }
 }

--- a/src/IntercomTags.php
+++ b/src/IntercomTags.php
@@ -5,39 +5,44 @@ namespace Intercom;
 class IntercomTags
 {
 
-  /** @var IntercomClient */
-  private $client;
+    /**
+     * @var IntercomClient 
+     */
+    private $client;
 
-  /**
-   * IntercomTags constructor.
-   * @param IntercomClient $client
-   */
-  public function __construct($client)
-  {
-      $this->client = $client;
-  }
+    /**
+     * IntercomTags constructor.
+     *
+     * @param IntercomClient $client
+     */
+    public function __construct($client)
+    {
+        $this->client = $client;
+    }
 
-  /**
-   * Creates a Tag.
-   * @see https://developers.intercom.io/reference#create-and-update-tags
-   * @param array $options
-   * @return mixed
-   * @throws \GuzzleHttp\Exception\GuzzleException
-   */
-  public function tag($options)
-  {
-      return $this->client->post("tags", $options);
-  }
+    /**
+     * Creates a Tag.
+     *
+     * @see    https://developers.intercom.io/reference#create-and-update-tags
+     * @param  array $options
+     * @return mixed
+     * @throws \GuzzleHttp\Exception\GuzzleException
+     */
+    public function tag($options)
+    {
+        return $this->client->post("tags", $options);
+    }
 
-  /**
-   * Lists Tags.
-   * @see https://developers.intercom.io/reference#list-tags-for-an-app
-   * @param array $options
-   * @return mixed
-   * @throws \GuzzleHttp\Exception\GuzzleException
-   */
-  public function getTags($options = [])
-  {
-      return $this->client->get("tags", $options);
-  }
+    /**
+     * Lists Tags.
+     *
+     * @see    https://developers.intercom.io/reference#list-tags-for-an-app
+     * @param  array $options
+     * @return mixed
+     * @throws \GuzzleHttp\Exception\GuzzleException
+     */
+    public function getTags($options = [])
+    {
+        return $this->client->get("tags", $options);
+    }
 }

--- a/src/IntercomUsers.php
+++ b/src/IntercomUsers.php
@@ -5,101 +5,110 @@ namespace Intercom;
 class IntercomUsers
 {
 
-  /** @var IntercomClient */
-  private $client;
+    /**
+     * @var IntercomClient 
+     */
+    private $client;
 
-  /**
-   * IntercomUsers constructor.
-   * @param IntercomClient $client
-   */
-  public function __construct($client)
-  {
-      $this->client = $client;
-  }
+    /**
+     * IntercomUsers constructor.
+     *
+     * @param IntercomClient $client
+     */
+    public function __construct($client)
+    {
+        $this->client = $client;
+    }
 
-  /**
-   * Creates a User.
-   * @see https://developers.intercom.io/reference#create-or-update-user
-   * @param array $options
-   * @return mixed
-   * @throws \GuzzleHttp\Exception\GuzzleException
-   */
-  public function create($options)
-  {
-      return $this->client->post("users", $options);
-  }
+    /**
+     * Creates a User.
+     *
+     * @see    https://developers.intercom.io/reference#create-or-update-user
+     * @param  array $options
+     * @return mixed
+     * @throws \GuzzleHttp\Exception\GuzzleException
+     */
+    public function create($options)
+    {
+        return $this->client->post("users", $options);
+    }
 
-  /**
-   * Creates a User.
-   * @see https://developers.intercom.io/reference#create-or-update-user
-   * @param array $options
-   * @return mixed
-   * @throws \GuzzleHttp\Exception\GuzzleException
-   */
-  public function update($options)
-  {
-      return $this->create($options);
-  }
+    /**
+     * Creates a User.
+     *
+     * @see    https://developers.intercom.io/reference#create-or-update-user
+     * @param  array $options
+     * @return mixed
+     * @throws \GuzzleHttp\Exception\GuzzleException
+     */
+    public function update($options)
+    {
+        return $this->create($options);
+    }
 
-  /**
-   * Lists Users.
-   * @see https://developers.intercom.io/reference#list-users
-   * @param array $options
-   * @return mixed
-   * @throws \GuzzleHttp\Exception\GuzzleException
-   */
-  public function getUsers($options)
-  {
-      return $this->client->get('users', $options);
-  }
+    /**
+     * Lists Users.
+     *
+     * @see    https://developers.intercom.io/reference#list-users
+     * @param  array $options
+     * @return mixed
+     * @throws \GuzzleHttp\Exception\GuzzleException
+     */
+    public function getUsers($options)
+    {
+        return $this->client->get('users', $options);
+    }
 
-  /**
-   * Gets a single User based on the Intercom ID.
-   * @see https://developers.intercom.com/reference#view-a-user
-   * @param string $id
-   * @param array $options
-   * @return mixed
-   * @throws \GuzzleHttp\Exception\GuzzleException
-   */
-  public function getUser($id, $options = [])
-  {
-      $path = $this->userPath($id);
-      return $this->client->get($path, $options);
-  }
+    /**
+     * Gets a single User based on the Intercom ID.
+     *
+     * @see    https://developers.intercom.com/reference#view-a-user
+     * @param  string $id
+     * @param  array  $options
+     * @return mixed
+     * @throws \GuzzleHttp\Exception\GuzzleException
+     */
+    public function getUser($id, $options = [])
+    {
+        $path = $this->userPath($id);
+        return $this->client->get($path, $options);
+    }
 
-  /**
-   * Gets a list of Users through the user scroll API.
-   * @see https://developers.intercom.com/reference#iterating-over-all-users
-   * @param array $options
-   * @return mixed
-   * @throws \GuzzleHttp\Exception\GuzzleException
-   */
-  public function scrollUsers($options = [])
-  {
-      return $this->client->get('users/scroll', $options);
-  }
+    /**
+     * Gets a list of Users through the user scroll API.
+     *
+     * @see    https://developers.intercom.com/reference#iterating-over-all-users
+     * @param  array $options
+     * @return mixed
+     * @throws \GuzzleHttp\Exception\GuzzleException
+     */
+    public function scrollUsers($options = [])
+    {
+        return $this->client->get('users/scroll', $options);
+    }
 
-  /**
-   * Deletes a single User based on the Intercom ID.
-   * @see https://developers.intercom.com/reference#delete-a-user
-   * @param string $id
-   * @param array $options
-   * @return mixed
-   * @throws \GuzzleHttp\Exception\GuzzleException
-   */
-  public function deleteUser($id, $options = [])
-  {
-      $path = $this->userPath($id);
-      return $this->client->delete($path, $options);
-  }
+    /**
+     * Deletes a single User based on the Intercom ID.
+     *
+     * @see    https://developers.intercom.com/reference#delete-a-user
+     * @param  string $id
+     * @param  array  $options
+     * @return mixed
+     * @throws \GuzzleHttp\Exception\GuzzleException
+     */
+    public function deleteUser($id, $options = [])
+    {
+        $path = $this->userPath($id);
+        return $this->client->delete($path, $options);
+    }
 
-  /**
-   * @param string $id
-   * @return string
-   */
-  public function userPath($id)
-  {
-      return 'users/' . $id;
-  }
+    /**
+     * @param string $id
+     * @return string
+     */
+    public function userPath($id)
+    {
+        return 'users/' . $id;
+    }
   
 }

--- a/src/IntercomVisitors.php
+++ b/src/IntercomVisitors.php
@@ -2,80 +2,89 @@
 
 namespace Intercom;
 
-class IntercomVisitors {
+class IntercomVisitors
+{
 
-  /** @var IntercomClient */
-  private $client;
+    /**
+     * @var IntercomClient 
+     */
+    private $client;
 
-  /**
-   * IntercomVisitors constructor.
-   * @param IntercomClient $client
-   */
-  public function __construct($client)
-  {
-    $this->client = $client;
-  }
+    /**
+     * IntercomVisitors constructor.
+     *
+     * @param IntercomClient $client
+     */
+    public function __construct($client)
+    {
+        $this->client = $client;
+    }
 
-  /**
-   * Updates Visitor.
-   * @see https://developers.intercom.com/reference#update-a-visitor
-   * @param array $options
-   * @return mixed
-   * @throws \GuzzleHttp\Exception\GuzzleException
-   */
-  public function update($options)
-  {
-    return $this->client->put("visitors", $options);
-  }
+    /**
+     * Updates Visitor.
+     *
+     * @see    https://developers.intercom.com/reference#update-a-visitor
+     * @param  array $options
+     * @return mixed
+     * @throws \GuzzleHttp\Exception\GuzzleException
+     */
+    public function update($options)
+    {
+        return $this->client->put("visitors", $options);
+    }
 
 
-  /**
-   * Returns single Visitor.
-   * @see https://developers.intercom.com/reference#view-a-visitor
-   * @param string $id
-   * @param array $options
-   * @return mixed
-   * @throws \GuzzleHttp\Exception\GuzzleException
-   */
-  public function getVisitor($id, $options = [])
-  {
-    $path = $this->visitorPath($id);
-    return $this->client->get($path, $options);
-  }
+    /**
+     * Returns single Visitor.
+     *
+     * @see    https://developers.intercom.com/reference#view-a-visitor
+     * @param  string $id
+     * @param  array  $options
+     * @return mixed
+     * @throws \GuzzleHttp\Exception\GuzzleException
+     */
+    public function getVisitor($id, $options = [])
+    {
+        $path = $this->visitorPath($id);
+        return $this->client->get($path, $options);
+    }
 
-  /**
-   * Deletes Visitor.
-   * @see https://developers.intercom.com/reference#delete-a-visitor
-   * @param string $id
-   * @param array $options
-   * @return mixed
-   * @throws \GuzzleHttp\Exception\GuzzleException
-   */
-  public function deleteVisitor($id, $options = [])
-  {
-    $path = $this->visitorPath($id);
-    return $this->client->delete($path, $options);
-  }
+    /**
+     * Deletes Visitor.
+     *
+     * @see    https://developers.intercom.com/reference#delete-a-visitor
+     * @param  string $id
+     * @param  array  $options
+     * @return mixed
+     * @throws \GuzzleHttp\Exception\GuzzleException
+     */
+    public function deleteVisitor($id, $options = [])
+    {
+        $path = $this->visitorPath($id);
+        return $this->client->delete($path, $options);
+    }
 
-  /**
-   * Converts Visitor.
-   * @see https://developers.intercom.io/reference#convert-a-lead
-   * @param $options
-   * @return mixed
-   * @throws \GuzzleHttp\Exception\GuzzleException
-   */
-  public function convertVisitor($options)
-  {
-    return $this->client->post("visitors/convert", $options);
-  }
+    /**
+     * Converts Visitor.
+     *
+     * @see    https://developers.intercom.io/reference#convert-a-lead
+     * @param  $options
+     * @return mixed
+     * @throws \GuzzleHttp\Exception\GuzzleException
+     */
+    public function convertVisitor($options)
+    {
+        return $this->client->post("visitors/convert", $options);
+    }
 
-  /**
-   * Returns endpoint path to Visitor with given ID.
-   * @param string $id
-   * @return string
-   */
-  public function visitorPath($id)
-  {
-    return "visitors/" . $id;
-  }
+    /**
+     * Returns endpoint path to Visitor with given ID.
+     *
+     * @param  string $id
+     * @return string
+     */
+    public function visitorPath($id)
+    {
+        return "visitors/" . $id;
+    }
 }

--- a/test/IntercomAdminsTest.php
+++ b/test/IntercomAdminsTest.php
@@ -2,30 +2,31 @@
 
 use Intercom\IntercomAdmins;
 
-class IntercomAdminsTest extends PHPUnit_Framework_TestCase {
-  public function testAdminsList()
-  {
-    $stub = $this->getMockBuilder('Intercom\IntercomClient')->disableOriginalConstructor()->getMock();
-    $stub->method('get')->willReturn('foo');
+class IntercomAdminsTest extends PHPUnit_Framework_TestCase
+{
+    public function testAdminsList()
+    {
+        $stub = $this->getMockBuilder('Intercom\IntercomClient')->disableOriginalConstructor()->getMock();
+        $stub->method('get')->willReturn('foo');
 
-    $users = new IntercomAdmins($stub);
-    $this->assertEquals('foo', $users->getAdmins());
-  }
+        $users = new IntercomAdmins($stub);
+        $this->assertEquals('foo', $users->getAdmins());
+    }
 
-  public function testAdminsGet()
-  {
-    $stub = $this->getMockBuilder('Intercom\IntercomClient')->disableOriginalConstructor()->getMock();
-    $stub->method('get')->willReturn('foo');
+    public function testAdminsGet()
+    {
+        $stub = $this->getMockBuilder('Intercom\IntercomClient')->disableOriginalConstructor()->getMock();
+        $stub->method('get')->willReturn('foo');
 
-    $users = new IntercomAdmins($stub);
-    $this->assertEquals('foo', $users->getAdmin(1));
-  }
+        $users = new IntercomAdmins($stub);
+        $this->assertEquals('foo', $users->getAdmin(1));
+    }
 
-  public function testAdminsGetPath()
-  {
-    $stub = $this->getMockBuilder('Intercom\IntercomClient')->disableOriginalConstructor()->getMock();
+    public function testAdminsGetPath()
+    {
+        $stub = $this->getMockBuilder('Intercom\IntercomClient')->disableOriginalConstructor()->getMock();
 
-    $users = new IntercomAdmins($stub);
-    $this->assertEquals('admins/1', $users->adminPath(1));
-  }
+        $users = new IntercomAdmins($stub);
+        $this->assertEquals('admins/1', $users->adminPath(1));
+    }
 }

--- a/test/IntercomBulkTest.php
+++ b/test/IntercomBulkTest.php
@@ -2,22 +2,23 @@
 
 use Intercom\IntercomBulk;
 
-class IntercomBulkTest extends PHPUnit_Framework_TestCase {
-  public function testBulkUsers()
-  {
-    $stub = $this->getMockBuilder('Intercom\IntercomClient')->disableOriginalConstructor()->getMock();
-    $stub->method('post')->will($this->returnArgument(0));
+class IntercomBulkTest extends PHPUnit_Framework_TestCase
+{
+    public function testBulkUsers()
+    {
+        $stub = $this->getMockBuilder('Intercom\IntercomClient')->disableOriginalConstructor()->getMock();
+        $stub->method('post')->will($this->returnArgument(0));
 
-    $bulk = new IntercomBulk($stub);
-    $this->assertEquals('bulk/users', $bulk->users([]));
-  }
+        $bulk = new IntercomBulk($stub);
+        $this->assertEquals('bulk/users', $bulk->users([]));
+    }
 
-  public function testBulkEvents()
-  {
-    $stub = $this->getMockBuilder('Intercom\IntercomClient')->disableOriginalConstructor()->getMock();
-    $stub->method('post')->will($this->returnArgument(0));
+    public function testBulkEvents()
+    {
+        $stub = $this->getMockBuilder('Intercom\IntercomClient')->disableOriginalConstructor()->getMock();
+        $stub->method('post')->will($this->returnArgument(0));
 
-    $bulk = new IntercomBulk($stub);
-    $this->assertEquals('bulk/events', $bulk->events([]));
-  }
+        $bulk = new IntercomBulk($stub);
+        $this->assertEquals('bulk/events', $bulk->events([]));
+    }
 }

--- a/test/IntercomClientTest.php
+++ b/test/IntercomClientTest.php
@@ -7,116 +7,131 @@ use GuzzleHttp\Psr7\Response;
 use GuzzleHttp\HandlerStack;
 use GuzzleHttp\Middleware;
 
-class IntercomClientTest extends PHPUnit_Framework_TestCase {
-  public function testBasicClient()
-  {
-    $mock = new MockHandler([
-      new Response(200, ['X-Foo' => 'Bar'], "{\"foo\":\"bar\"}")
-    ]);
+class IntercomClientTest extends PHPUnit_Framework_TestCase
+{
+    public function testBasicClient()
+    {
+        $mock = new MockHandler(
+            [
+            new Response(200, ['X-Foo' => 'Bar'], "{\"foo\":\"bar\"}")
+            ]
+        );
 
-    $container = [];
-    $history = Middleware::history($container);
-    $stack = HandlerStack::create($mock);
-    $stack->push($history);
+        $container = [];
+        $history = Middleware::history($container);
+        $stack = HandlerStack::create($mock);
+        $stack->push($history);
 
-    $http_client = new Client(['handler' => $stack]);
+        $http_client = new Client(['handler' => $stack]);
 
-    $client = new IntercomClient('u', 'p');
-    $client->setClient($http_client);
+        $client = new IntercomClient('u', 'p');
+        $client->setClient($http_client);
 
-    $client->users->create([
-      'email' => 'test@intercom.io'
-    ]);
+        $client->users->create(
+            [
+            'email' => 'test@intercom.io'
+            ]
+        );
 
-    foreach ($container as $transaction) {
-      $basic = $transaction['request']->getHeaders()['Authorization'][0];
-      $this->assertTrue($basic == "Basic dTpw");
+        foreach ($container as $transaction) {
+            $basic = $transaction['request']->getHeaders()['Authorization'][0];
+            $this->assertTrue($basic == "Basic dTpw");
+        }
     }
-  }
 
-  public function testExtendedClient()
-  {
-    $mock = new MockHandler([
-        new Response(200, ['X-Foo' => 'Bar'], "{\"foo\":\"bar\"}")
-    ]);
+    public function testExtendedClient()
+    {
+        $mock = new MockHandler(
+            [
+            new Response(200, ['X-Foo' => 'Bar'], "{\"foo\":\"bar\"}")
+            ]
+        );
 
-    $container = [];
-    $history = Middleware::history($container);
-    $stack = HandlerStack::create($mock);
-    $stack->push($history);
+        $container = [];
+        $history = Middleware::history($container);
+        $stack = HandlerStack::create($mock);
+        $stack->push($history);
 
-    $http_client = new Client(['handler' => $stack]);
+        $http_client = new Client(['handler' => $stack]);
 
-    $client = new IntercomClient('u', 'p', ['connect_timeout' => 10]);
-    $client->setClient($http_client);
+        $client = new IntercomClient('u', 'p', ['connect_timeout' => 10]);
+        $client->setClient($http_client);
 
-    $client->users->create([
-        'email' => 'test@intercom.io'
-    ]);
+        $client->users->create(
+            [
+            'email' => 'test@intercom.io'
+            ]
+        );
 
-    foreach ($container as $transaction) {
-      $basic = $client->getGuzzleRequestOptions()['connect_timeout'];
-      $this->assertTrue($basic == 10);
+        foreach ($container as $transaction) {
+            $basic = $client->getGuzzleRequestOptions()['connect_timeout'];
+            $this->assertTrue($basic == 10);
+        }
     }
-  }
 
 
-  public function testPaginationHelper()
-  {
-    $mock = new MockHandler([
-      new Response(200, ['X-Foo' => 'Bar'], "{\"foo\":\"bar\"}")
-    ]);
+    public function testPaginationHelper()
+    {
+        $mock = new MockHandler(
+            [
+            new Response(200, ['X-Foo' => 'Bar'], "{\"foo\":\"bar\"}")
+            ]
+        );
 
-    $container = [];
-    $history = Middleware::history($container);
-    $stack = HandlerStack::create($mock);
-    $stack->push($history);
+        $container = [];
+        $history = Middleware::history($container);
+        $stack = HandlerStack::create($mock);
+        $stack->push($history);
 
-    $http_client = new Client(['handler' => $stack]);
+        $http_client = new Client(['handler' => $stack]);
 
-    $client = new IntercomClient('u', 'p');
-    $client->setClient($http_client);
+        $client = new IntercomClient('u', 'p');
+        $client->setClient($http_client);
 
-    $pages = new stdClass;
-    $pages->next = 'https://foo.com';
+        $pages = new stdClass;
+        $pages->next = 'https://foo.com';
 
-    $client->nextPage($pages);
+        $client->nextPage($pages);
 
-    foreach ($container as $transaction) {
-      $host = $transaction['request']->getUri()->getHost();
-      $this->assertTrue($host == "foo.com");
+        foreach ($container as $transaction) {
+            $host = $transaction['request']->getUri()->getHost();
+            $this->assertTrue($host == "foo.com");
+        }
     }
-  }
 
-  public function testRateLimitDetails()
-  {
-    date_default_timezone_set('UTC');
-    $time = time() + 7;
-    $mock = new MockHandler([
-        new Response(200, ['X-RateLimit-Limit' => '83', 'X-RateLimit-Remaining' => '2', 'X-RateLimit-Reset' => $time], "{\"foo\":\"bar\"}")
-    ]);
+    public function testRateLimitDetails()
+    {
+        date_default_timezone_set('UTC');
+        $time = time() + 7;
+        $mock = new MockHandler(
+            [
+            new Response(200, ['X-RateLimit-Limit' => '83', 'X-RateLimit-Remaining' => '2', 'X-RateLimit-Reset' => $time], "{\"foo\":\"bar\"}")
+            ]
+        );
 
-    $container = [];
-    $history = Middleware::history($container);
-    $stack = HandlerStack::create($mock);
-    $stack->push($history);
+        $container = [];
+        $history = Middleware::history($container);
+        $stack = HandlerStack::create($mock);
+        $stack->push($history);
 
-    $http_client = new Client(['handler' => $stack]);
+        $http_client = new Client(['handler' => $stack]);
 
-    $client = new IntercomClient('u', 'p');
-    $client->setClient($http_client);
+        $client = new IntercomClient('u', 'p');
+        $client->setClient($http_client);
 
-    $client->users->create([
-        'email' => 'test@intercom.io'
-    ]);
+        $client->users->create(
+            [
+            'email' => 'test@intercom.io'
+            ]
+        );
 
-    $rateLimitDetails = $client->getRateLimitDetails();
-    $this->assertInternalType('array', $rateLimitDetails);
-    $this->assertArrayHasKey('limit', $rateLimitDetails);
-    $this->assertArrayHasKey('remaining', $rateLimitDetails);
-    $this->assertArrayHasKey('reset_at', $rateLimitDetails);
-    $this->assertEquals(83, $rateLimitDetails['limit']);
-    $this->assertEquals(2, $rateLimitDetails['remaining']);
-    $this->assertEquals((new DateTimeImmutable)->setTimestamp($time), $rateLimitDetails['reset_at']);
-  }
+        $rateLimitDetails = $client->getRateLimitDetails();
+        $this->assertInternalType('array', $rateLimitDetails);
+        $this->assertArrayHasKey('limit', $rateLimitDetails);
+        $this->assertArrayHasKey('remaining', $rateLimitDetails);
+        $this->assertArrayHasKey('reset_at', $rateLimitDetails);
+        $this->assertEquals(83, $rateLimitDetails['limit']);
+        $this->assertEquals(2, $rateLimitDetails['remaining']);
+        $this->assertEquals((new DateTimeImmutable)->setTimestamp($time), $rateLimitDetails['reset_at']);
+    }
 }

--- a/test/IntercomCompaniesTest.php
+++ b/test/IntercomCompaniesTest.php
@@ -8,31 +8,32 @@ use GuzzleHttp\Psr7\Response;
 use GuzzleHttp\HandlerStack;
 use GuzzleHttp\Middleware;
 
-class IntercomCompaniesTest extends PHPUnit_Framework_TestCase {
-  public function testCompanyCreate()
-  {
-    $stub = $this->getMockBuilder('Intercom\IntercomClient')->disableOriginalConstructor()->getMock();
-    $stub->method('post')->willReturn('foo');
+class IntercomCompaniesTest extends PHPUnit_Framework_TestCase
+{
+    public function testCompanyCreate()
+    {
+        $stub = $this->getMockBuilder('Intercom\IntercomClient')->disableOriginalConstructor()->getMock();
+        $stub->method('post')->willReturn('foo');
 
-    $companies = new IntercomCompanies($stub);
-    $this->assertEquals('foo', $companies->create([]));
-  }
+        $companies = new IntercomCompanies($stub);
+        $this->assertEquals('foo', $companies->create([]));
+    }
 
-  public function testCompanyUpdate()
-  {
-    $stub = $this->getMockBuilder('Intercom\IntercomClient')->disableOriginalConstructor()->getMock();
-    $stub->method('post')->willReturn('foo');
+    public function testCompanyUpdate()
+    {
+        $stub = $this->getMockBuilder('Intercom\IntercomClient')->disableOriginalConstructor()->getMock();
+        $stub->method('post')->willReturn('foo');
 
-    $companies = new IntercomCompanies($stub);
-    $this->assertEquals('foo', $companies->update([]));
-  }
+        $companies = new IntercomCompanies($stub);
+        $this->assertEquals('foo', $companies->update([]));
+    }
 
-  public function testCompanyGet()
-  {
-    $stub = $this->getMockBuilder('Intercom\IntercomClient')->disableOriginalConstructor()->getMock();
-    $stub->method('get')->willReturn('foo');
+    public function testCompanyGet()
+    {
+        $stub = $this->getMockBuilder('Intercom\IntercomClient')->disableOriginalConstructor()->getMock();
+        $stub->method('get')->willReturn('foo');
 
-    $companies = new IntercomCompanies($stub);
-    $this->assertEquals('foo', $companies->getCompanies([]));
-  }
+        $companies = new IntercomCompanies($stub);
+        $this->assertEquals('foo', $companies->getCompanies([]));
+    }
 }

--- a/test/IntercomConversationsTest.php
+++ b/test/IntercomConversationsTest.php
@@ -8,45 +8,46 @@ use GuzzleHttp\Psr7\Response;
 use GuzzleHttp\HandlerStack;
 use GuzzleHttp\Middleware;
 
-class IntercomConversationsTest extends PHPUnit_Framework_TestCase {
-  public function testConversationsList()
-  {
-    $stub = $this->getMockBuilder('Intercom\IntercomClient')->disableOriginalConstructor()->getMock();
-    $stub->method('get')->willReturn('foo');
+class IntercomConversationsTest extends PHPUnit_Framework_TestCase
+{
+    public function testConversationsList()
+    {
+        $stub = $this->getMockBuilder('Intercom\IntercomClient')->disableOriginalConstructor()->getMock();
+        $stub->method('get')->willReturn('foo');
 
-    $users = new IntercomConversations($stub);
-    $this->assertEquals('foo', $users->getConversations([]));
-  }
+        $users = new IntercomConversations($stub);
+        $this->assertEquals('foo', $users->getConversations([]));
+    }
 
-  public function testConversationPath()
-  {
-    $stub = $this->getMockBuilder('Intercom\IntercomClient')->disableOriginalConstructor()->getMock();
-    $users = new IntercomConversations($stub);
-    $this->assertEquals('conversations/foo', $users->conversationPath("foo"));
-  }
+    public function testConversationPath()
+    {
+        $stub = $this->getMockBuilder('Intercom\IntercomClient')->disableOriginalConstructor()->getMock();
+        $users = new IntercomConversations($stub);
+        $this->assertEquals('conversations/foo', $users->conversationPath("foo"));
+    }
 
-  public function testGetConversation()
-  {
-    $stub = $this->getMockBuilder('Intercom\IntercomClient')->disableOriginalConstructor()->getMock();
-    $stub->method('get')->willReturn('foo');
+    public function testGetConversation()
+    {
+        $stub = $this->getMockBuilder('Intercom\IntercomClient')->disableOriginalConstructor()->getMock();
+        $stub->method('get')->willReturn('foo');
 
-    $users = new IntercomConversations($stub);
-    $this->assertEquals('foo', $users->getConversation("foo"));
-  }
+        $users = new IntercomConversations($stub);
+        $this->assertEquals('foo', $users->getConversation("foo"));
+    }
 
-  public function testConversationReplyPath()
-  {
-    $stub = $this->getMockBuilder('Intercom\IntercomClient')->disableOriginalConstructor()->getMock();
-    $users = new IntercomConversations($stub);
-    $this->assertEquals('conversations/foo/reply', $users->conversationReplyPath("foo"));
-  }
+    public function testConversationReplyPath()
+    {
+        $stub = $this->getMockBuilder('Intercom\IntercomClient')->disableOriginalConstructor()->getMock();
+        $users = new IntercomConversations($stub);
+        $this->assertEquals('conversations/foo/reply', $users->conversationReplyPath("foo"));
+    }
 
-  public function testReplyToConversation()
-  {
-    $stub = $this->getMockBuilder('Intercom\IntercomClient')->disableOriginalConstructor()->getMock();
-    $stub->method('post')->willReturn('foo');
+    public function testReplyToConversation()
+    {
+        $stub = $this->getMockBuilder('Intercom\IntercomClient')->disableOriginalConstructor()->getMock();
+        $stub->method('post')->willReturn('foo');
 
-    $users = new IntercomConversations($stub);
-    $this->assertEquals('foo', $users->replyToConversation("bar", []));
-  }
+        $users = new IntercomConversations($stub);
+        $this->assertEquals('foo', $users->replyToConversation("bar", []));
+    }
 }

--- a/test/IntercomCountsTest.php
+++ b/test/IntercomCountsTest.php
@@ -2,13 +2,14 @@
 
 use Intercom\IntercomCounts;
 
-class IntercomCountsTest extends PHPUnit_Framework_TestCase {
-  public function testCountsList()
-  {
-    $stub = $this->getMockBuilder('Intercom\IntercomClient')->disableOriginalConstructor()->getMock();
-    $stub->method('get')->willReturn('foo');
+class IntercomCountsTest extends PHPUnit_Framework_TestCase
+{
+    public function testCountsList()
+    {
+        $stub = $this->getMockBuilder('Intercom\IntercomClient')->disableOriginalConstructor()->getMock();
+        $stub->method('get')->willReturn('foo');
 
-    $counts = new IntercomCounts($stub);
-    $this->assertEquals('foo', $counts->getCounts([]));
-  }
+        $counts = new IntercomCounts($stub);
+        $this->assertEquals('foo', $counts->getCounts([]));
+    }
 }

--- a/test/IntercomEventsTest.php
+++ b/test/IntercomEventsTest.php
@@ -8,22 +8,23 @@ use GuzzleHttp\Psr7\Response;
 use GuzzleHttp\HandlerStack;
 use GuzzleHttp\Middleware;
 
-class IntercomEventsTest extends PHPUnit_Framework_TestCase {
-  public function testEventCreate()
-  {
-    $stub = $this->getMockBuilder('Intercom\IntercomClient')->disableOriginalConstructor()->getMock();
-    $stub->method('post')->willReturn('foo');
+class IntercomEventsTest extends PHPUnit_Framework_TestCase
+{
+    public function testEventCreate()
+    {
+        $stub = $this->getMockBuilder('Intercom\IntercomClient')->disableOriginalConstructor()->getMock();
+        $stub->method('post')->willReturn('foo');
 
-    $users = new IntercomEvents($stub);
-    $this->assertEquals('foo', $users->create([]));
-  }
+        $users = new IntercomEvents($stub);
+        $this->assertEquals('foo', $users->create([]));
+    }
 
-  public function testEventsGet()
-  {
-    $stub = $this->getMockBuilder('Intercom\IntercomClient')->disableOriginalConstructor()->getMock();
-    $stub->method('get')->willReturn('foo');
+    public function testEventsGet()
+    {
+        $stub = $this->getMockBuilder('Intercom\IntercomClient')->disableOriginalConstructor()->getMock();
+        $stub->method('get')->willReturn('foo');
 
-    $users = new IntercomEvents($stub);
-    $this->assertEquals('foo', $users->getEvents([]));
-  }
+        $users = new IntercomEvents($stub);
+        $this->assertEquals('foo', $users->getEvents([]));
+    }
 }

--- a/test/IntercomLeadsTest.php
+++ b/test/IntercomLeadsTest.php
@@ -2,65 +2,66 @@
 
 use Intercom\IntercomLeads;
 
-class IntercomLeadsTest extends PHPUnit_Framework_TestCase {
-  public function testLeadCreate()
-  {
-    $stub = $this->getMockBuilder('Intercom\IntercomClient')->disableOriginalConstructor()->getMock();
-    $stub->method('post')->willReturn('foo');
+class IntercomLeadsTest extends PHPUnit_Framework_TestCase
+{
+    public function testLeadCreate()
+    {
+        $stub = $this->getMockBuilder('Intercom\IntercomClient')->disableOriginalConstructor()->getMock();
+        $stub->method('post')->willReturn('foo');
 
-    $leads = new IntercomLeads($stub);
-    $this->assertEquals('foo', $leads->create([]));
-  }
+        $leads = new IntercomLeads($stub);
+        $this->assertEquals('foo', $leads->create([]));
+    }
 
-  public function testLeadUpdate()
-  {
-    $stub = $this->getMockBuilder('Intercom\IntercomClient')->disableOriginalConstructor()->getMock();
-    $stub->method('post')->willReturn('foo');
+    public function testLeadUpdate()
+    {
+        $stub = $this->getMockBuilder('Intercom\IntercomClient')->disableOriginalConstructor()->getMock();
+        $stub->method('post')->willReturn('foo');
 
-    $leads = new IntercomLeads($stub);
-    $this->assertEquals('foo', $leads->update([]));
-  }
+        $leads = new IntercomLeads($stub);
+        $this->assertEquals('foo', $leads->update([]));
+    }
 
-  public function testLeadsList()
-  {
-    $stub = $this->getMockBuilder('Intercom\IntercomClient')->disableOriginalConstructor()->getMock();
-    $stub->method('get')->willReturn('foo');
+    public function testLeadsList()
+    {
+        $stub = $this->getMockBuilder('Intercom\IntercomClient')->disableOriginalConstructor()->getMock();
+        $stub->method('get')->willReturn('foo');
 
-    $leads = new IntercomLeads($stub);
-    $this->assertEquals('foo', $leads->getLeads([]));
-  }
+        $leads = new IntercomLeads($stub);
+        $this->assertEquals('foo', $leads->getLeads([]));
+    }
 
-  public function testLeadPath()
-  {
-    $stub = $this->getMockBuilder('Intercom\IntercomClient')->disableOriginalConstructor()->getMock();
-    $leads = new IntercomLeads($stub);
-    $this->assertEquals($leads->leadPath("foo"), "contacts/foo");
-  }
+    public function testLeadPath()
+    {
+        $stub = $this->getMockBuilder('Intercom\IntercomClient')->disableOriginalConstructor()->getMock();
+        $leads = new IntercomLeads($stub);
+        $this->assertEquals($leads->leadPath("foo"), "contacts/foo");
+    }
 
-  public function testLeadsGet()
-  {
-    $stub = $this->getMockBuilder('Intercom\IntercomClient')->disableOriginalConstructor()->getMock();
-    $stub->method('get')->willReturn('foo');
+    public function testLeadsGet()
+    {
+        $stub = $this->getMockBuilder('Intercom\IntercomClient')->disableOriginalConstructor()->getMock();
+        $stub->method('get')->willReturn('foo');
 
-    $leads = new IntercomLeads($stub);
-    $this->assertEquals('foo', $leads->getLead("bar"));
-  }
+        $leads = new IntercomLeads($stub);
+        $this->assertEquals('foo', $leads->getLead("bar"));
+    }
 
-  public function testLeadsConvert()
-  {
-    $stub = $this->getMockBuilder('Intercom\IntercomClient')->disableOriginalConstructor()->getMock();
-    $stub->method('post')->will($this->returnArgument(0));
+    public function testLeadsConvert()
+    {
+        $stub = $this->getMockBuilder('Intercom\IntercomClient')->disableOriginalConstructor()->getMock();
+        $stub->method('post')->will($this->returnArgument(0));
 
-    $leads = new IntercomLeads($stub);
-    $this->assertEquals('contacts/convert', $leads->convertLead([]));
-  }
+        $leads = new IntercomLeads($stub);
+        $this->assertEquals('contacts/convert', $leads->convertLead([]));
+    }
 
-  public function testLeadsDelete()
-  {
-    $stub = $this->getMockBuilder('Intercom\IntercomClient')->disableOriginalConstructor()->getMock();
-    $stub->method('delete')->willReturn('foo');
+    public function testLeadsDelete()
+    {
+        $stub = $this->getMockBuilder('Intercom\IntercomClient')->disableOriginalConstructor()->getMock();
+        $stub->method('delete')->willReturn('foo');
 
-    $leads = new IntercomLeads($stub);
-    $this->assertEquals('foo', $leads->deleteLead("bar"));
-  }
+        $leads = new IntercomLeads($stub);
+        $this->assertEquals('foo', $leads->deleteLead("bar"));
+    }
 }

--- a/test/IntercomMessagesTest.php
+++ b/test/IntercomMessagesTest.php
@@ -8,13 +8,14 @@ use GuzzleHttp\Psr7\Response;
 use GuzzleHttp\HandlerStack;
 use GuzzleHttp\Middleware;
 
-class IntercomMessagesTest extends PHPUnit_Framework_TestCase {
-  public function testMessageCreate()
-  {
-    $stub = $this->getMockBuilder('Intercom\IntercomClient')->disableOriginalConstructor()->getMock();
-    $stub->method('post')->willReturn('foo');
+class IntercomMessagesTest extends PHPUnit_Framework_TestCase
+{
+    public function testMessageCreate()
+    {
+        $stub = $this->getMockBuilder('Intercom\IntercomClient')->disableOriginalConstructor()->getMock();
+        $stub->method('post')->willReturn('foo');
 
-    $messages = new IntercomMessages($stub);
-    $this->assertEquals('foo', $messages->create([]));
-  }
+        $messages = new IntercomMessages($stub);
+        $this->assertEquals('foo', $messages->create([]));
+    }
 }

--- a/test/IntercomNotesTest.php
+++ b/test/IntercomNotesTest.php
@@ -2,31 +2,32 @@
 
 use Intercom\IntercomNotes;
 
-class IntercomNotesTest extends PHPUnit_Framework_TestCase {
-  public function testNoteCreate()
-  {
-    $stub = $this->getMockBuilder('Intercom\IntercomClient')->disableOriginalConstructor()->getMock();
-    $stub->method('post')->willReturn('foo');
+class IntercomNotesTest extends PHPUnit_Framework_TestCase
+{
+    public function testNoteCreate()
+    {
+        $stub = $this->getMockBuilder('Intercom\IntercomClient')->disableOriginalConstructor()->getMock();
+        $stub->method('post')->willReturn('foo');
 
-    $notes = new IntercomNotes($stub);
-    $this->assertEquals('foo', $notes->create([]));
-  }
+        $notes = new IntercomNotes($stub);
+        $this->assertEquals('foo', $notes->create([]));
+    }
 
-  public function testNotesList()
-  {
-    $stub = $this->getMockBuilder('Intercom\IntercomClient')->disableOriginalConstructor()->getMock();
-    $stub->method('get')->willReturn('foo');
+    public function testNotesList()
+    {
+        $stub = $this->getMockBuilder('Intercom\IntercomClient')->disableOriginalConstructor()->getMock();
+        $stub->method('get')->willReturn('foo');
 
-    $notes = new IntercomNotes($stub);
-    $this->assertEquals('foo', $notes->getNotes([]));
-  }
+        $notes = new IntercomNotes($stub);
+        $this->assertEquals('foo', $notes->getNotes([]));
+    }
 
-  public function testNotesGet()
-  {
-    $stub = $this->getMockBuilder('Intercom\IntercomClient')->disableOriginalConstructor()->getMock();
-    $stub->method('get')->will($this->returnArgument(0));
+    public function testNotesGet()
+    {
+        $stub = $this->getMockBuilder('Intercom\IntercomClient')->disableOriginalConstructor()->getMock();
+        $stub->method('get')->will($this->returnArgument(0));
 
-    $notes = new IntercomNotes($stub);
-    $this->assertEquals('notes/foo', $notes->getNote("foo"));
-  }
+        $notes = new IntercomNotes($stub);
+        $this->assertEquals('notes/foo', $notes->getNote("foo"));
+    }
 }

--- a/test/IntercomSegmentsTest.php
+++ b/test/IntercomSegmentsTest.php
@@ -2,14 +2,15 @@
 
 use Intercom\IntercomSegments;
 
-class IntercomSegmentTest extends PHPUnit_Framework_TestCase {
+class IntercomSegmentTest extends PHPUnit_Framework_TestCase
+{
 
-  public function testSegmentList()
-  {
-    $stub = $this->getMockBuilder('Intercom\IntercomClient')->disableOriginalConstructor()->getMock();
-    $stub->method('get')->willReturn('foo');
+    public function testSegmentList()
+    {
+        $stub = $this->getMockBuilder('Intercom\IntercomClient')->disableOriginalConstructor()->getMock();
+        $stub->method('get')->willReturn('foo');
 
-    $segments = new IntercomSegments($stub);
-    $this->assertEquals('foo', $segments->getSegments());
-  }
+        $segments = new IntercomSegments($stub);
+        $this->assertEquals('foo', $segments->getSegments());
+    }
 }

--- a/test/IntercomTagsTest.php
+++ b/test/IntercomTagsTest.php
@@ -2,22 +2,23 @@
 
 use Intercom\IntercomTags;
 
-class IntercomTagsTest extends PHPUnit_Framework_TestCase {
-  public function testTagUsers()
-  {
-    $stub = $this->getMockBuilder('Intercom\IntercomClient')->disableOriginalConstructor()->getMock();
-    $stub->method('post')->willReturn('foo');
+class IntercomTagsTest extends PHPUnit_Framework_TestCase
+{
+    public function testTagUsers()
+    {
+        $stub = $this->getMockBuilder('Intercom\IntercomClient')->disableOriginalConstructor()->getMock();
+        $stub->method('post')->willReturn('foo');
 
-    $tags = new IntercomTags($stub);
-    $this->assertEquals('foo', $tags->tag([]));
-  }
+        $tags = new IntercomTags($stub);
+        $this->assertEquals('foo', $tags->tag([]));
+    }
 
-  public function testTagsList()
-  {
-    $stub = $this->getMockBuilder('Intercom\IntercomClient')->disableOriginalConstructor()->getMock();
-    $stub->method('get')->willReturn('foo');
+    public function testTagsList()
+    {
+        $stub = $this->getMockBuilder('Intercom\IntercomClient')->disableOriginalConstructor()->getMock();
+        $stub->method('get')->willReturn('foo');
 
-    $tags = new IntercomTags($stub);
-    $this->assertEquals('foo', $tags->getTags());
-  }
+        $tags = new IntercomTags($stub);
+        $this->assertEquals('foo', $tags->getTags());
+    }
 }

--- a/test/IntercomUsersTest.php
+++ b/test/IntercomUsersTest.php
@@ -8,31 +8,32 @@ use GuzzleHttp\Psr7\Response;
 use GuzzleHttp\HandlerStack;
 use GuzzleHttp\Middleware;
 
-class IntercomUsersTest extends PHPUnit_Framework_TestCase {
-  public function testUserCreate()
-  {
-    $stub = $this->getMockBuilder('Intercom\IntercomClient')->disableOriginalConstructor()->getMock();
-    $stub->method('post')->willReturn('foo');
+class IntercomUsersTest extends PHPUnit_Framework_TestCase
+{
+    public function testUserCreate()
+    {
+        $stub = $this->getMockBuilder('Intercom\IntercomClient')->disableOriginalConstructor()->getMock();
+        $stub->method('post')->willReturn('foo');
 
-    $users = new IntercomUsers($stub);
-    $this->assertEquals('foo', $users->create([]));
-  }
+        $users = new IntercomUsers($stub);
+        $this->assertEquals('foo', $users->create([]));
+    }
 
-  public function testUserUpdate()
-  {
-    $stub = $this->getMockBuilder('Intercom\IntercomClient')->disableOriginalConstructor()->getMock();
-    $stub->method('post')->willReturn('foo');
+    public function testUserUpdate()
+    {
+        $stub = $this->getMockBuilder('Intercom\IntercomClient')->disableOriginalConstructor()->getMock();
+        $stub->method('post')->willReturn('foo');
 
-    $users = new IntercomUsers($stub);
-    $this->assertEquals('foo', $users->update([]));
-  }
+        $users = new IntercomUsers($stub);
+        $this->assertEquals('foo', $users->update([]));
+    }
 
-  public function testUserGet()
-  {
-    $stub = $this->getMockBuilder('Intercom\IntercomClient')->disableOriginalConstructor()->getMock();
-    $stub->method('get')->willReturn('foo');
+    public function testUserGet()
+    {
+        $stub = $this->getMockBuilder('Intercom\IntercomClient')->disableOriginalConstructor()->getMock();
+        $stub->method('get')->willReturn('foo');
 
-    $users = new IntercomUsers($stub);
-    $this->assertEquals('foo', $users->getUsers([]));
-  }
+        $users = new IntercomUsers($stub);
+        $this->assertEquals('foo', $users->getUsers([]));
+    }
 }

--- a/test/IntercomVisitorsTest.php
+++ b/test/IntercomVisitorsTest.php
@@ -2,48 +2,49 @@
 
 use Intercom\IntercomVisitors;
 
-class IntercomVisitorsTest extends PHPUnit_Framework_TestCase {
+class IntercomVisitorsTest extends PHPUnit_Framework_TestCase
+{
 
-  public function testVisitorUpdate()
-  {
-    $stub = $this->getMockBuilder('Intercom\IntercomClient')->disableOriginalConstructor()->getMock();
-    $stub->method('put')->willReturn('foo');
+    public function testVisitorUpdate()
+    {
+        $stub = $this->getMockBuilder('Intercom\IntercomClient')->disableOriginalConstructor()->getMock();
+        $stub->method('put')->willReturn('foo');
 
-    $visitors = new IntercomVisitors($stub);
-    $this->assertEquals('foo', $visitors->update([]));
-  }
+        $visitors = new IntercomVisitors($stub);
+        $this->assertEquals('foo', $visitors->update([]));
+    }
 
-  public function testVisitorPath()
-  {
-    $stub = $this->getMockBuilder('Intercom\IntercomClient')->disableOriginalConstructor()->getMock();
-    $visitors = new IntercomVisitors($stub);
-    $this->assertEquals($visitors->visitorPath("foo"), "visitors/foo");
-  }
+    public function testVisitorPath()
+    {
+        $stub = $this->getMockBuilder('Intercom\IntercomClient')->disableOriginalConstructor()->getMock();
+        $visitors = new IntercomVisitors($stub);
+        $this->assertEquals($visitors->visitorPath("foo"), "visitors/foo");
+    }
 
-  public function testVisitorsGet()
-  {
-    $stub = $this->getMockBuilder('Intercom\IntercomClient')->disableOriginalConstructor()->getMock();
-    $stub->method('get')->willReturn('foo');
+    public function testVisitorsGet()
+    {
+        $stub = $this->getMockBuilder('Intercom\IntercomClient')->disableOriginalConstructor()->getMock();
+        $stub->method('get')->willReturn('foo');
 
-    $visitors = new IntercomVisitors($stub);
-    $this->assertEquals('foo', $visitors->getVisitor("bar"));
-  }
+        $visitors = new IntercomVisitors($stub);
+        $this->assertEquals('foo', $visitors->getVisitor("bar"));
+    }
 
-  public function testVisitorsConvert()
-  {
-    $stub = $this->getMockBuilder('Intercom\IntercomClient')->disableOriginalConstructor()->getMock();
-    $stub->method('post')->will($this->returnArgument(0));
+    public function testVisitorsConvert()
+    {
+        $stub = $this->getMockBuilder('Intercom\IntercomClient')->disableOriginalConstructor()->getMock();
+        $stub->method('post')->will($this->returnArgument(0));
 
-    $visitors = new IntercomVisitors($stub);
-    $this->assertEquals('visitors/convert', $visitors->convertVisitor([]));
-  }
+        $visitors = new IntercomVisitors($stub);
+        $this->assertEquals('visitors/convert', $visitors->convertVisitor([]));
+    }
 
-  public function testVisitorsDelete()
-  {
-    $stub = $this->getMockBuilder('Intercom\IntercomClient')->disableOriginalConstructor()->getMock();
-    $stub->method('delete')->willReturn('foo');
+    public function testVisitorsDelete()
+    {
+        $stub = $this->getMockBuilder('Intercom\IntercomClient')->disableOriginalConstructor()->getMock();
+        $stub->method('delete')->willReturn('foo');
 
-    $visitors = new IntercomVisitors($stub);
-    $this->assertEquals('foo', $visitors->deleteVisitor("bar"));
-  }
+        $visitors = new IntercomVisitors($stub);
+        $this->assertEquals('foo', $visitors->deleteVisitor("bar"));
+    }
 }


### PR DESCRIPTION
As surfaced correctly in #218, the library is currently not following the [PSR-2 Coding Style Guidelines](http://www.php-fig.org/psr/psr-2/), which makes it more difficult for developers to contribute with the fear of adding inconsistencies.

This is a not a full attempt to bring the project up to scratch, but I think we should start at least with the consistency in whitespacing, indenting and comments.

I ran `phpcs 3.1.0 stable` with the default configuration options.

To keep track of the changes, these are the summaries and reports through this process:

First `phpcs` scan to both `/src` and `/test`: [src](https://gist.github.com/kmossco/09b1642ef1d3e87033b76a5369c3e190#file-phpcs_src_initial-txt) - [test](https://gist.github.com/kmossco/09b1642ef1d3e87033b76a5369c3e190#file-phpcs_test_initial-txt)
Summary of `phpcbf`  to both folders: [src](https://gist.github.com/kmossco/09b1642ef1d3e87033b76a5369c3e190#file-phpcbf_src-txt) - [test](https://gist.github.com/kmossco/09b1642ef1d3e87033b76a5369c3e190#file-phpcbf_test-txt)
Report of remaining errors and warning in both folders: [src](https://gist.github.com/kmossco/09b1642ef1d3e87033b76a5369c3e190#file-phpcs_src_final-txt) - [test](https://gist.github.com/kmossco/09b1642ef1d3e87033b76a5369c3e190#file-phpcs_test_final-txt)

To ensure that nothing broke, ran multiple times PHPUnit:

```bash
PHPUnit 4.0.20 by Sebastian Bergmann.

Configuration read from /Users/bruno/src/intercom-php/phpunit.xml

..........................................

Time: 76 ms, Memory: 4.00MB

OK (42 tests, 48 assertions)
```