### PR TITLE
added scroll for leads

### DIFF
--- a/README.md
+++ b/README.md
@@ -146,6 +146,14 @@ $client->leads->convertLead([
     "email" => "winstonsmith@truth.org"
   ]
 ]);
+
+/** 
+ * List all leads (even above 10k records)
+ * The result object contains an array of your contacts objects and a scroll_param which you can then 
+ * use to request the next 100 leads. Note that the scroll parameter will time out after one minute 
+ * and you will need to make a new request
+ */
+$client->leads->scrollLeads();
 ```
 
 ## Visitors

--- a/src/IntercomLeads.php
+++ b/src/IntercomLeads.php
@@ -112,4 +112,17 @@ class IntercomLeads
     {
         return "contacts/" . $id;
     }
+
+    /**
+     * Gets a list of Leads through the contacts scroll API.
+     *
+     * @see    https://developers.intercom.com/v2.0/reference#iterating-over-all-leads
+     * @param  array $options
+     * @return mixed
+     * @throws \GuzzleHttp\Exception\GuzzleException
+     */
+    public function scrollLeads($options = [])
+    {
+        return $this->client->get('contacts/scroll', $options);
+    }
 }

--- a/test/IntercomLeadsTest.php
+++ b/test/IntercomLeadsTest.php
@@ -64,4 +64,13 @@ class IntercomLeadsTest extends PHPUnit_Framework_TestCase
         $leads = new IntercomLeads($stub);
         $this->assertEquals('foo', $leads->deleteLead("bar"));
     }
+
+    public function testLeadsScroll()
+    {
+        $stub = $this->getMockBuilder('Intercom\IntercomClient')->disableOriginalConstructor()->getMock();
+        $stub->method('get')->willReturn('foo');
+
+        $leads = new IntercomLeads($stub);
+        $this->assertEquals('foo', $leads->scrollLeads([]));
+    }
 }


### PR DESCRIPTION
With PR #186 we have added the ability to use the Scroll API to list more than 10k users, and this PR adds the same ability for leads.