### PR TITLE
Update PHP version requirement for CircleCI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,4 +1,6 @@
 language: php
 php:
   - 5.6
+  - 7.0
+  - 7.1
 install: composer install

--- a/circle.yml
+++ b/circle.yml
@@ -1,0 +1,3 @@
+machine:
+  php:
+    version: 5.6.14


### PR DESCRIPTION
- Update CircleCI config to use PHP5.6 (was failing with 5.3)
- Update Travis to run unit tests with PHP7, see https://github.com/intercom/intercom/issues/63977