### PR TITLE
Introduces the Ability to Permanently Delete a User

### DIFF
--- a/src/IntercomUsers.php
+++ b/src/IntercomUsers.php
@@ -90,7 +90,22 @@ class IntercomUsers
     /**
      * Deletes a single User based on the Intercom ID.
      *
-     * @see    https://developers.intercom.com/reference#delete-a-user
+     * @see    https://developers.intercom.com/reference#archive-a-user
+     * @param  string $id
+     * @param  array  $options
+     * @return mixed
+     * @throws \GuzzleHttp\Exception\GuzzleException
+     */
+    public function archiveUser($id, $options = [])
+    {
+        $path = $this->userPath($id);
+        return $this->client->delete($path, $options);
+    }
+
+    /**
+     * Deletes a single User based on the Intercom ID.
+     *
+     * @see    https://developers.intercom.com/reference#archive-a-user
      * @param  string $id
      * @param  array  $options
      * @return mixed
@@ -98,8 +113,22 @@ class IntercomUsers
      */
     public function deleteUser($id, $options = [])
     {
-        $path = $this->userPath($id);
-        return $this->client->delete($path, $options);
+        return $this->archiveUser($id, $options);
+    }
+
+    /**
+     * Permanently deletes a single User based on the Intercom ID.
+     *
+     * @see   https://developers.intercom.com/reference#delete-users
+     * @param string $id
+     * @return mixed
+     * @throws \GuzzleHttp\Exception\GuzzleException
+     */
+    public function permanentlyDeleteUser($id)
+    {
+        return $this->client->post('user_delete_requests', [
+            'intercom_user_id' => $id
+        ]);
     }
 
     /**

--- a/test/IntercomUsersTest.php
+++ b/test/IntercomUsersTest.php
@@ -36,4 +36,31 @@ class IntercomUsersTest extends PHPUnit_Framework_TestCase
         $users = new IntercomUsers($stub);
         $this->assertEquals('foo', $users->getUsers([]));
     }
+
+    public function testArchiveUser()
+    {
+        $stub = $this->getMockBuilder('Intercom\IntercomClient')->disableOriginalConstructor()->getMock();
+        $stub->method('delete')->willReturn('foo');
+
+        $users = new IntercomUsers($stub);
+        $this->assertEquals('foo', $users->archiveUser(''));
+    }
+
+    public function testDeleteUser()
+    {
+        $stub = $this->getMockBuilder('Intercom\IntercomClient')->disableOriginalConstructor()->getMock();
+        $stub->method('delete')->willReturn('foo');
+
+        $users = new IntercomUsers($stub);
+        $this->assertEquals('foo', $users->deleteUser(''));
+    }
+
+    public function testPermanentlyDeleteUser()
+    {
+        $stub = $this->getMockBuilder('Intercom\IntercomClient')->disableOriginalConstructor()->getMock();
+        $stub->method('post')->willReturn('foo');
+
+        $users = new IntercomUsers($stub);
+        $this->assertEquals('foo', $users->permanentlyDeleteUser(''));
+    }
 }


### PR DESCRIPTION
The changes here include some updating of documentation. It seems that the old delete method was really just archiving the user, based on the official documentation, so I updated the docblock to reflect that.

I also introduced `permanentlyDeleteUser` based on the recommendations in #249 that leverage the `user_delete_requests` endpoint to issue a permanent delete.