### PR TITLE
Update docblock type for `$json` parameter

### DIFF
--- a/src/IntercomClient.php
+++ b/src/IntercomClient.php
@@ -141,7 +141,7 @@ class IntercomClient
      * Sends POST request to Intercom API.
      *
      * @param  string $endpoint
-     * @param  string $json
+     * @param  array $json
      * @return mixed
      * @throws \GuzzleHttp\Exception\GuzzleException
      */
@@ -164,7 +164,7 @@ class IntercomClient
      * Sends PUT request to Intercom API.
      *
      * @param  string $endpoint
-     * @param  string $json
+     * @param  array $json
      * @return mixed
      * @throws \GuzzleHttp\Exception\GuzzleException
      */
@@ -188,7 +188,7 @@ class IntercomClient
      * Sends DELETE request to Intercom API.
      *
      * @param  string $endpoint
-     * @param  string $json
+     * @param  array $json
      * @return mixed
      * @throws \GuzzleHttp\Exception\GuzzleException
      */


### PR DESCRIPTION
This `$json` parameter passed as a Guzzle `json` request option is intended to be an `array` as referenced in the calling Intercom endpoint classes.