### PR TITLE
Remove Travis cI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,0 @@
-language: php
-php:
-  - 5.6
-  - 7.0
-  - 7.1
-install: composer install


### PR DESCRIPTION
#### Why?
Removing Travis so we only use circle ci 