### PR TITLE
Add linting to CI

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -10,3 +10,4 @@ jobs:
       - checkout
       - run: composer install --no-interaction
       - run: vendor/bin/phpunit
+      - run: vendor/bin/phpcs --standard=PSR2 src test

--- a/composer.json
+++ b/composer.json
@@ -14,6 +14,11 @@
             "Intercom\\": ["src"]
         }
     },
+    "autoload-dev": {
+        "psr-4": {
+            "Intercom\\Test\\": ["test"]
+        }
+    },
     "require": {
         "php": ">= 5.6",
         "ext-json": "*",

--- a/test/IntercomAdminsTest.php
+++ b/test/IntercomAdminsTest.php
@@ -3,8 +3,9 @@
 namespace Intercom\Test;
 
 use Intercom\IntercomAdmins;
+use PHPUnit_Framework_TestCase;
 
-class IntercomAdminsTest extends \PHPUnit_Framework_TestCase
+class IntercomAdminsTest extends PHPUnit_Framework_TestCase
 {
     public function testAdminsList()
     {

--- a/test/IntercomAdminsTest.php
+++ b/test/IntercomAdminsTest.php
@@ -1,5 +1,7 @@
 <?php
 
+namespace Intercom\Test;
+
 use Intercom\IntercomAdmins;
 
 class IntercomAdminsTest extends PHPUnit_Framework_TestCase

--- a/test/IntercomAdminsTest.php
+++ b/test/IntercomAdminsTest.php
@@ -4,7 +4,7 @@ namespace Intercom\Test;
 
 use Intercom\IntercomAdmins;
 
-class IntercomAdminsTest extends PHPUnit_Framework_TestCase
+class IntercomAdminsTest extends \PHPUnit_Framework_TestCase
 {
     public function testAdminsList()
     {

--- a/test/IntercomBulkTest.php
+++ b/test/IntercomBulkTest.php
@@ -3,8 +3,9 @@
 namespace Intercom\Test;
 
 use Intercom\IntercomBulk;
+use PHPUnit_Framework_TestCase;
 
-class IntercomBulkTest extends \PHPUnit_Framework_TestCase
+class IntercomBulkTest extends PHPUnit_Framework_TestCase
 {
     public function testBulkUsers()
     {

--- a/test/IntercomBulkTest.php
+++ b/test/IntercomBulkTest.php
@@ -1,5 +1,7 @@
 <?php
 
+namespace Intercom\Test;
+
 use Intercom\IntercomBulk;
 
 class IntercomBulkTest extends PHPUnit_Framework_TestCase

--- a/test/IntercomBulkTest.php
+++ b/test/IntercomBulkTest.php
@@ -4,7 +4,7 @@ namespace Intercom\Test;
 
 use Intercom\IntercomBulk;
 
-class IntercomBulkTest extends PHPUnit_Framework_TestCase
+class IntercomBulkTest extends \PHPUnit_Framework_TestCase
 {
     public function testBulkUsers()
     {

--- a/test/IntercomClientTest.php
+++ b/test/IntercomClientTest.php
@@ -1,5 +1,7 @@
 <?php
 
+namespace Intercom\Test;
+
 use Intercom\IntercomClient;
 use GuzzleHttp\Client;
 use GuzzleHttp\Handler\MockHandler;

--- a/test/IntercomClientTest.php
+++ b/test/IntercomClientTest.php
@@ -9,9 +9,10 @@ use GuzzleHttp\Handler\MockHandler;
 use GuzzleHttp\Psr7\Response;
 use GuzzleHttp\HandlerStack;
 use GuzzleHttp\Middleware;
+use PHPUnit_Framework_TestCase;
 use stdClass;
 
-class IntercomClientTest extends \PHPUnit_Framework_TestCase
+class IntercomClientTest extends PHPUnit_Framework_TestCase
 {
     public function testBasicClient()
     {

--- a/test/IntercomClientTest.php
+++ b/test/IntercomClientTest.php
@@ -2,14 +2,16 @@
 
 namespace Intercom\Test;
 
+use DateTimeImmutable;
 use Intercom\IntercomClient;
 use GuzzleHttp\Client;
 use GuzzleHttp\Handler\MockHandler;
 use GuzzleHttp\Psr7\Response;
 use GuzzleHttp\HandlerStack;
 use GuzzleHttp\Middleware;
+use stdClass;
 
-class IntercomClientTest extends PHPUnit_Framework_TestCase
+class IntercomClientTest extends \PHPUnit_Framework_TestCase
 {
     public function testBasicClient()
     {

--- a/test/IntercomCompaniesTest.php
+++ b/test/IntercomCompaniesTest.php
@@ -3,14 +3,9 @@
 namespace Intercom\Test;
 
 use Intercom\IntercomCompanies;
-use Intercom\IntercomClient;
-use GuzzleHttp\Client;
-use GuzzleHttp\Handler\MockHandler;
-use GuzzleHttp\Psr7\Response;
-use GuzzleHttp\HandlerStack;
-use GuzzleHttp\Middleware;
+use PHPUnit_Framework_TestCase;
 
-class IntercomCompaniesTest extends \PHPUnit_Framework_TestCase
+class IntercomCompaniesTest extends PHPUnit_Framework_TestCase
 {
     public function testCompanyCreate()
     {

--- a/test/IntercomCompaniesTest.php
+++ b/test/IntercomCompaniesTest.php
@@ -10,7 +10,7 @@ use GuzzleHttp\Psr7\Response;
 use GuzzleHttp\HandlerStack;
 use GuzzleHttp\Middleware;
 
-class IntercomCompaniesTest extends PHPUnit_Framework_TestCase
+class IntercomCompaniesTest extends \PHPUnit_Framework_TestCase
 {
     public function testCompanyCreate()
     {

--- a/test/IntercomCompaniesTest.php
+++ b/test/IntercomCompaniesTest.php
@@ -1,5 +1,7 @@
 <?php
 
+namespace Intercom\Test;
+
 use Intercom\IntercomCompanies;
 use Intercom\IntercomClient;
 use GuzzleHttp\Client;

--- a/test/IntercomConversationsTest.php
+++ b/test/IntercomConversationsTest.php
@@ -10,7 +10,7 @@ use GuzzleHttp\Psr7\Response;
 use GuzzleHttp\HandlerStack;
 use GuzzleHttp\Middleware;
 
-class IntercomConversationsTest extends PHPUnit_Framework_TestCase
+class IntercomConversationsTest extends \PHPUnit_Framework_TestCase
 {
     public function testConversationsList()
     {

--- a/test/IntercomConversationsTest.php
+++ b/test/IntercomConversationsTest.php
@@ -3,14 +3,9 @@
 namespace Intercom\Test;
 
 use Intercom\IntercomConversations;
-use Intercom\IntercomClient;
-use GuzzleHttp\Client;
-use GuzzleHttp\Handler\MockHandler;
-use GuzzleHttp\Psr7\Response;
-use GuzzleHttp\HandlerStack;
-use GuzzleHttp\Middleware;
+use PHPUnit_Framework_TestCase;
 
-class IntercomConversationsTest extends \PHPUnit_Framework_TestCase
+class IntercomConversationsTest extends PHPUnit_Framework_TestCase
 {
     public function testConversationsList()
     {

--- a/test/IntercomConversationsTest.php
+++ b/test/IntercomConversationsTest.php
@@ -1,5 +1,7 @@
 <?php
 
+namespace Intercom\Test;
+
 use Intercom\IntercomConversations;
 use Intercom\IntercomClient;
 use GuzzleHttp\Client;

--- a/test/IntercomCountsTest.php
+++ b/test/IntercomCountsTest.php
@@ -4,7 +4,7 @@ namespace Intercom\Test;
 
 use Intercom\IntercomCounts;
 
-class IntercomCountsTest extends PHPUnit_Framework_TestCase
+class IntercomCountsTest extends \PHPUnit_Framework_TestCase
 {
     public function testCountsList()
     {

--- a/test/IntercomCountsTest.php
+++ b/test/IntercomCountsTest.php
@@ -3,8 +3,9 @@
 namespace Intercom\Test;
 
 use Intercom\IntercomCounts;
+use PHPUnit_Framework_TestCase;
 
-class IntercomCountsTest extends \PHPUnit_Framework_TestCase
+class IntercomCountsTest extends PHPUnit_Framework_TestCase
 {
     public function testCountsList()
     {

--- a/test/IntercomCountsTest.php
+++ b/test/IntercomCountsTest.php
@@ -1,5 +1,7 @@
 <?php
 
+namespace Intercom\Test;
+
 use Intercom\IntercomCounts;
 
 class IntercomCountsTest extends PHPUnit_Framework_TestCase

--- a/test/IntercomEventsTest.php
+++ b/test/IntercomEventsTest.php
@@ -1,5 +1,7 @@
 <?php
 
+namespace Intercom\Test;
+
 use Intercom\IntercomEvents;
 use Intercom\IntercomClient;
 use GuzzleHttp\Client;

--- a/test/IntercomEventsTest.php
+++ b/test/IntercomEventsTest.php
@@ -10,7 +10,7 @@ use GuzzleHttp\Psr7\Response;
 use GuzzleHttp\HandlerStack;
 use GuzzleHttp\Middleware;
 
-class IntercomEventsTest extends PHPUnit_Framework_TestCase
+class IntercomEventsTest extends \PHPUnit_Framework_TestCase
 {
     public function testEventCreate()
     {

--- a/test/IntercomEventsTest.php
+++ b/test/IntercomEventsTest.php
@@ -3,14 +3,9 @@
 namespace Intercom\Test;
 
 use Intercom\IntercomEvents;
-use Intercom\IntercomClient;
-use GuzzleHttp\Client;
-use GuzzleHttp\Handler\MockHandler;
-use GuzzleHttp\Psr7\Response;
-use GuzzleHttp\HandlerStack;
-use GuzzleHttp\Middleware;
+use PHPUnit_Framework_TestCase;
 
-class IntercomEventsTest extends \PHPUnit_Framework_TestCase
+class IntercomEventsTest extends PHPUnit_Framework_TestCase
 {
     public function testEventCreate()
     {

--- a/test/IntercomLeadsTest.php
+++ b/test/IntercomLeadsTest.php
@@ -4,7 +4,7 @@ namespace Intercom\Test;
 
 use Intercom\IntercomLeads;
 
-class IntercomLeadsTest extends PHPUnit_Framework_TestCase
+class IntercomLeadsTest extends \PHPUnit_Framework_TestCase
 {
     public function testLeadCreate()
     {

--- a/test/IntercomLeadsTest.php
+++ b/test/IntercomLeadsTest.php
@@ -3,8 +3,9 @@
 namespace Intercom\Test;
 
 use Intercom\IntercomLeads;
+use PHPUnit_Framework_TestCase;
 
-class IntercomLeadsTest extends \PHPUnit_Framework_TestCase
+class IntercomLeadsTest extends PHPUnit_Framework_TestCase
 {
     public function testLeadCreate()
     {

--- a/test/IntercomLeadsTest.php
+++ b/test/IntercomLeadsTest.php
@@ -1,5 +1,7 @@
 <?php
 
+namespace Intercom\Test;
+
 use Intercom\IntercomLeads;
 
 class IntercomLeadsTest extends PHPUnit_Framework_TestCase

--- a/test/IntercomMessagesTest.php
+++ b/test/IntercomMessagesTest.php
@@ -1,5 +1,7 @@
 <?php
 
+namespace Intercom\Test;
+
 use Intercom\IntercomMessages;
 use Intercom\IntercomClient;
 use GuzzleHttp\Client;

--- a/test/IntercomMessagesTest.php
+++ b/test/IntercomMessagesTest.php
@@ -3,14 +3,8 @@
 namespace Intercom\Test;
 
 use Intercom\IntercomMessages;
-use Intercom\IntercomClient;
-use GuzzleHttp\Client;
-use GuzzleHttp\Handler\MockHandler;
-use GuzzleHttp\Psr7\Response;
-use GuzzleHttp\HandlerStack;
-use GuzzleHttp\Middleware;
 
-class IntercomMessagesTest extends PHPUnit_Framework_TestCase
+class IntercomMessagesTest extends \PHPUnit_Framework_TestCase
 {
     public function testMessageCreate()
     {

--- a/test/IntercomMessagesTest.php
+++ b/test/IntercomMessagesTest.php
@@ -3,8 +3,9 @@
 namespace Intercom\Test;
 
 use Intercom\IntercomMessages;
+use PHPUnit_Framework_TestCase;
 
-class IntercomMessagesTest extends \PHPUnit_Framework_TestCase
+class IntercomMessagesTest extends PHPUnit_Framework_TestCase
 {
     public function testMessageCreate()
     {

--- a/test/IntercomNotesTest.php
+++ b/test/IntercomNotesTest.php
@@ -1,5 +1,7 @@
 <?php
 
+namespace Intercom\Test;
+
 use Intercom\IntercomNotes;
 
 class IntercomNotesTest extends PHPUnit_Framework_TestCase

--- a/test/IntercomNotesTest.php
+++ b/test/IntercomNotesTest.php
@@ -3,8 +3,9 @@
 namespace Intercom\Test;
 
 use Intercom\IntercomNotes;
+use PHPUnit_Framework_TestCase;
 
-class IntercomNotesTest extends \PHPUnit_Framework_TestCase
+class IntercomNotesTest extends PHPUnit_Framework_TestCase
 {
     public function testNoteCreate()
     {

--- a/test/IntercomNotesTest.php
+++ b/test/IntercomNotesTest.php
@@ -4,7 +4,7 @@ namespace Intercom\Test;
 
 use Intercom\IntercomNotes;
 
-class IntercomNotesTest extends PHPUnit_Framework_TestCase
+class IntercomNotesTest extends \PHPUnit_Framework_TestCase
 {
     public function testNoteCreate()
     {

--- a/test/IntercomSegmentsTest.php
+++ b/test/IntercomSegmentsTest.php
@@ -3,8 +3,9 @@
 namespace Intercom\Test;
 
 use Intercom\IntercomSegments;
+use PHPUnit_Framework_TestCase;
 
-class IntercomSegmentTest extends \PHPUnit_Framework_TestCase
+class IntercomSegmentTest extends PHPUnit_Framework_TestCase
 {
 
     public function testSegmentList()

--- a/test/IntercomSegmentsTest.php
+++ b/test/IntercomSegmentsTest.php
@@ -1,5 +1,7 @@
 <?php
 
+namespace Intercom\Test;
+
 use Intercom\IntercomSegments;
 
 class IntercomSegmentTest extends PHPUnit_Framework_TestCase

--- a/test/IntercomSegmentsTest.php
+++ b/test/IntercomSegmentsTest.php
@@ -4,7 +4,7 @@ namespace Intercom\Test;
 
 use Intercom\IntercomSegments;
 
-class IntercomSegmentTest extends PHPUnit_Framework_TestCase
+class IntercomSegmentTest extends \PHPUnit_Framework_TestCase
 {
 
     public function testSegmentList()

--- a/test/IntercomTagsTest.php
+++ b/test/IntercomTagsTest.php
@@ -4,7 +4,7 @@ namespace Intercom\Test;
 
 use Intercom\IntercomTags;
 
-class IntercomTagsTest extends PHPUnit_Framework_TestCase
+class IntercomTagsTest extends \PHPUnit_Framework_TestCase
 {
     public function testTagUsers()
     {

--- a/test/IntercomTagsTest.php
+++ b/test/IntercomTagsTest.php
@@ -3,8 +3,9 @@
 namespace Intercom\Test;
 
 use Intercom\IntercomTags;
+use PHPUnit_Framework_TestCase;
 
-class IntercomTagsTest extends \PHPUnit_Framework_TestCase
+class IntercomTagsTest extends PHPUnit_Framework_TestCase
 {
     public function testTagUsers()
     {

--- a/test/IntercomTagsTest.php
+++ b/test/IntercomTagsTest.php
@@ -1,5 +1,7 @@
 <?php
 
+namespace Intercom\Test;
+
 use Intercom\IntercomTags;
 
 class IntercomTagsTest extends PHPUnit_Framework_TestCase

--- a/test/IntercomUsersTest.php
+++ b/test/IntercomUsersTest.php
@@ -1,5 +1,7 @@
 <?php
 
+namespace Intercom\Test;
+
 use Intercom\IntercomUsers;
 use Intercom\IntercomClient;
 use GuzzleHttp\Client;

--- a/test/IntercomUsersTest.php
+++ b/test/IntercomUsersTest.php
@@ -10,7 +10,7 @@ use GuzzleHttp\Psr7\Response;
 use GuzzleHttp\HandlerStack;
 use GuzzleHttp\Middleware;
 
-class IntercomUsersTest extends PHPUnit_Framework_TestCase
+class IntercomUsersTest extends \PHPUnit_Framework_TestCase
 {
     public function testUserCreate()
     {

--- a/test/IntercomUsersTest.php
+++ b/test/IntercomUsersTest.php
@@ -3,14 +3,9 @@
 namespace Intercom\Test;
 
 use Intercom\IntercomUsers;
-use Intercom\IntercomClient;
-use GuzzleHttp\Client;
-use GuzzleHttp\Handler\MockHandler;
-use GuzzleHttp\Psr7\Response;
-use GuzzleHttp\HandlerStack;
-use GuzzleHttp\Middleware;
+use PHPUnit_Framework_TestCase;
 
-class IntercomUsersTest extends \PHPUnit_Framework_TestCase
+class IntercomUsersTest extends PHPUnit_Framework_TestCase
 {
     public function testUserCreate()
     {

--- a/test/IntercomVisitorsTest.php
+++ b/test/IntercomVisitorsTest.php
@@ -4,7 +4,7 @@ namespace Intercom\Test;
 
 use Intercom\IntercomVisitors;
 
-class IntercomVisitorsTest extends PHPUnit_Framework_TestCase
+class IntercomVisitorsTest extends \PHPUnit_Framework_TestCase
 {
 
     public function testVisitorUpdate()

--- a/test/IntercomVisitorsTest.php
+++ b/test/IntercomVisitorsTest.php
@@ -3,8 +3,9 @@
 namespace Intercom\Test;
 
 use Intercom\IntercomVisitors;
+use PHPUnit_Framework_TestCase;
 
-class IntercomVisitorsTest extends \PHPUnit_Framework_TestCase
+class IntercomVisitorsTest extends PHPUnit_Framework_TestCase
 {
 
     public function testVisitorUpdate()

--- a/test/IntercomVisitorsTest.php
+++ b/test/IntercomVisitorsTest.php
@@ -1,5 +1,7 @@
 <?php
 
+namespace Intercom\Test;
+
 use Intercom\IntercomVisitors;
 
 class IntercomVisitorsTest extends PHPUnit_Framework_TestCase


### PR DESCRIPTION
#### Why?
The PSR2 convention is followed in all the source files, so why not enforce PSR2 via CI 😃 

#### How?
I added the PHP Code Sniffer validation to the CircleCI build. However, the tests were not compliant.

To make them compliant:
* I had to add a namespace to each of them
* After having a namespace, all un-namespaced dependencies (`PHPUnit_Framework_TestCase`, `stdClass` and `DateTimeImmutable`) need to either be imported with an `use` statement or include a backward slash in front of them.
