### PR TITLE
phpdoc typehint fix

### DIFF
--- a/src/IntercomClient.php
+++ b/src/IntercomClient.php
@@ -102,7 +102,7 @@ class IntercomClient
      * IntercomClient constructor.
      *
      * @param string $usernamePart App ID.
-     * @param string $passwordPart Api Key.
+     * @param string|null $passwordPart Api Key.
      * @param array  $extraGuzzleRequestsOptions Extra Guzzle request options.
      */
     public function __construct($usernamePart, $passwordPart, $extraGuzzleRequestsOptions = [])


### PR DESCRIPTION
#### Why?
phpstan analyse on my project using intercom-php fails because of the incorrect phpdoc.

#### How?
`$passwordPart` can be null on `IntercomClient` if access token is used.
https://github.com/intercom/intercom-php#clients
