### PR TITLE
Add event metadata example to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -245,7 +245,8 @@ $client->events->create([
     "email" => "test@example.com",
     "metadata" => [
         "order_date" => 1392036272,
-        "stripe_invoice" => "inv_3434343434" ]
+        "stripe_invoice" => "inv_3434343434"
+    ]
 ]);
 
 /** View events for a user */

--- a/README.md
+++ b/README.md
@@ -242,7 +242,10 @@ $client->segments->getSegment("59c124f770e00fd819b9ce81", ["include_count"=>"tru
 $client->events->create([
     "event_name" => "testing",
     "created_at" => 1391691571,
-    "email" => "test@example.com"
+    "email" => "test@example.com",
+    "metadata" => [
+        "order_date" => 1392036272,
+        "stripe_invoice" => "inv_3434343434" ]
 ]);
 
 /** View events for a user */


### PR DESCRIPTION
#### Why?
Event metadata isn't documented in the README

#### How?

![image](https://user-images.githubusercontent.com/5289860/49028637-c0ff1400-f19a-11e8-93ec-dcc02eb3e34d.png)
