### PR TITLE
Abstract the HTTP client using HTTPPlug

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,34 +9,22 @@ Official PHP bindings to the Intercom API
 
 This library supports PHP 7.1 and later
 
+Please note this library uses [HTTPPlug](https://github.com/php-http/httplug) as HTTP client. HTTP Plug is only an abstraction, so you need to provide it with an adapter for the HTTP library you prefer. You can find the available adapters [here](http://docs.php-http.org/en/latest/clients.html). The example below assumes you use Guzzle6 as your HTTP library.
+
 The recommended way to install intercom-php is through [Composer](https://getcomposer.org):
 
-First, install Composer:
-
 ```sh
-curl -sS https://getcomposer.org/installer | php
-```
-
-Next, install the latest intercom-php:
-
-```sh
-php composer.phar require intercom/intercom-php
-```
-
-Finally, you need to require the library in your PHP application:
-
-```php
-require "vendor/autoload.php";
+composer require intercom/intercom-php php-http/guzzle6-adapter
 ```
 
 ## Clients
 
-For OAuth or Access Tokens use:
+Initialize your client using your access token:
 
 ```php
 use Intercom\IntercomClient;
 
-$client = new IntercomClient('<insert_token_here>', null);
+$client = new IntercomClient('<insert_token_here>');
 ```
 
 > If you already have an access token you can find it [here](https://app.intercom.com/a/apps/_/developer-hub). If you want to create or learn more about access tokens then you can find more info [here](https://developers.intercom.com/building-apps/docs/authorization#section-access-tokens).

--- a/README.md
+++ b/README.md
@@ -30,14 +30,14 @@ $client = new IntercomClient('<insert_token_here>');
 >
 > If you are building a third party application you can get your OAuth token by [setting-up-oauth](https://developers.intercom.com/building-apps/docs/authorization#section-oauth) for Intercom.
 
-For most of the use cases, the code snippet above is just enough. However, for most specific scenarios, you can include custom request headers, or even pass in your own HTTP client, request factory or URI factory:
+For most use cases the code snippet above should suffice. However, if needed, you can customize the Intercom client as follows:
 
 ```php
 use Intercom\IntercomClient;
 
 $client = new IntercomClient('<insert_token_here>', null, ['Custom-Header' => 'value']);
 
-$client->setClient($myCustomHttpClient); // $myCustomHttpClient implements Psr\Http\Client\ClientInterface
+$client->setHttpClient($myCustomHttpClient); // $myCustomHttpClient implements Psr\Http\Client\ClientInterface
 $client->setRequestFactory($myCustomRequestFactory); // $myCustomRequestFactory implements Http\Message\RequestFactory
 $client->setUriFactory($myCustomUriFactory); // $myCustomUriFactory implements Http\Message\UriFactory
 ```

--- a/README.md
+++ b/README.md
@@ -1,7 +1,6 @@
 # intercom-php
 
-[![Code
-Climate](https://codeclimate.com/repos/537da4a7e30ba062b101be9c/badges/2aa25d4736f09f40282e/gpa.svg)](https://codeclimate.com/repos/537da4a7e30ba062b101be9c/feed) [![Circle CI](https://circleci.com/gh/intercom/intercom-php.png?style=badge)](https://circleci.com/gh/intercom/intercom-php)
+[![Code Climate](https://codeclimate.com/repos/537da4a7e30ba062b101be9c/badges/2aa25d4736f09f40282e/gpa.svg)](https://codeclimate.com/repos/537da4a7e30ba062b101be9c/feed) [![Circle CI](https://circleci.com/gh/intercom/intercom-php.png?style=badge)](https://circleci.com/gh/intercom/intercom-php)
 
 Official PHP bindings to the Intercom API
 
@@ -9,7 +8,7 @@ Official PHP bindings to the Intercom API
 
 This library supports PHP 7.1 and later
 
-Please note this library uses [HTTPPlug](https://github.com/php-http/httplug) as HTTP client. HTTP Plug is only an abstraction, so you need to provide it with an adapter for the HTTP library you prefer. You can find the available adapters [here](http://docs.php-http.org/en/latest/clients.html). The example below assumes you use Guzzle6 as your HTTP library.
+This library uses [HTTPPlug](https://github.com/php-http/httplug) as HTTP client. HTTP Plug is an abstraction that allows this library to support many different HTTP Clients. Therefore, you need to provide it with an adapter for the HTTP library you prefer. You can find the available adapters [here](http://docs.php-http.org/en/latest/clients.html). The example below assumes you use Guzzle6 as your HTTP library, but you can replace it with any adapter that you prefer.
 
 The recommended way to install intercom-php is through [Composer](https://getcomposer.org):
 
@@ -30,6 +29,18 @@ $client = new IntercomClient('<insert_token_here>');
 > If you already have an access token you can find it [here](https://app.intercom.com/a/apps/_/developer-hub). If you want to create or learn more about access tokens then you can find more info [here](https://developers.intercom.com/building-apps/docs/authorization#section-access-tokens).
 >
 > If you are building a third party application you can get your OAuth token by [setting-up-oauth](https://developers.intercom.com/building-apps/docs/authorization#section-oauth) for Intercom.
+
+For most of the use cases, the code snippet above is just enough. However, for most specific scenarios, you can include custom request headers, or even pass in your own HTTP client, request factory or URI factory:
+
+```php
+use Intercom\IntercomClient;
+
+$client = new IntercomClient('<insert_token_here>', null, ['Custom-Header' => 'value']);
+
+$client->setClient($myCustomHttpClient); // $myCustomHttpClient implements Psr\Http\Client\ClientInterface
+$client->setRequestFactory($myCustomRequestFactory); // $myCustomRequestFactory implements Http\Message\RequestFactory
+$client->setUriFactory($myCustomUriFactory); // $myCustomUriFactory implements Http\Message\UriFactory
+```
 
 ## Users
 

--- a/README.md
+++ b/README.md
@@ -457,19 +457,15 @@ while (!empty($resp->scroll_param) && sizeof($resp->users) > 0) {
 
 ## Exceptions
 
-Exceptions are handled by the HTTP client that you chose during the installation of this library. The following example assumes you chose `php-http/guzzle6-adapter`.
+Exceptions are handled by HTTPPlug. Every exception thrown implements `Http\Client\Exception`. See the different exceptions that can be thrown [in the HTTPPlug documentation](http://docs.php-http.org/en/latest/httplug/exceptions.html).
 The Intercom API may return an unsuccessful HTTP response, for example when a resource is not found (404).
-If you want to catch errors you can wrap your API call into a try/catch:
+If you want to catch errors you can wrap your API call into a try/catch block:
 
 ```php
-use GuzzleHttp\Exception\ClientException;
-
 try {
     $user = $client->users->getUser("570680a8a1bcbca8a90001b9");
-} catch(ClientException $e) {
-    $response = $e->getResponse();
-    $statusCode = $response->getStatusCode();
-    if ($statusCode == '404') {
+} catch(Http\Client\Exception $e) {
+    if ($e->getCode() == '404') {
         // Handle 404 error
         return;
     } else {

--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ Official PHP bindings to the Intercom API
 
 This library supports PHP 7.1 and later
 
-This library uses [HTTPPlug](https://github.com/php-http/httplug) as HTTP client. HTTP Plug is an abstraction that allows this library to support many different HTTP Clients. Therefore, you need to provide it with an adapter for the HTTP library you prefer. You can find the available adapters [here](http://docs.php-http.org/en/latest/clients.html). The example below assumes you use Guzzle6 as your HTTP library, but you can replace it with any adapter that you prefer.
+This library uses [HTTPPlug](https://github.com/php-http/httplug) as HTTP client. HTTPPlug is an abstraction that allows this library to support many different HTTP Clients. Therefore, you need to provide it with an adapter for the HTTP library you prefer. You can find the available adapters [here](http://docs.php-http.org/en/latest/clients.html). This documentation assumes you use the Guzzle6 Client, but you can replace it with any adapter that you prefer.
 
 The recommended way to install intercom-php is through [Composer](https://getcomposer.org):
 
@@ -457,7 +457,7 @@ while (!empty($resp->scroll_param) && sizeof($resp->users) > 0) {
 
 ## Exceptions
 
-Exceptions are handled by [Guzzle](https://github.com/guzzle/guzzle).
+Exceptions are handled by the HTTP client that you chose during the installation of this library. The following example assumes you chose `php-http/guzzle6-adapter`.
 The Intercom API may return an unsuccessful HTTP response, for example when a resource is not found (404).
 If you want to catch errors you can wrap your API call into a try/catch:
 

--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ Official PHP bindings to the Intercom API
 
 This library supports PHP 7.1 and later
 
-This library uses [HTTPPlug](https://github.com/php-http/httplug) as HTTP client. HTTPPlug is an abstraction that allows this library to support many different HTTP Clients. Therefore, you need to provide it with an adapter for the HTTP library you prefer. You can find the available adapters [here](http://docs.php-http.org/en/latest/clients.html). This documentation assumes you use the Guzzle6 Client, but you can replace it with any adapter that you prefer.
+This library uses [HTTPPlug](https://github.com/php-http/httplug) as HTTP client. HTTPPlug is an abstraction that allows this library to support many different HTTP Clients. Therefore, you need to provide it with an adapter for the HTTP library you prefer. You can find all the available adapters [in Packagist](https://packagist.org/providers/php-http/client-implementation). This documentation assumes you use the Guzzle6 Client, but you can replace it with any adapter that you prefer.
 
 The recommended way to install intercom-php is through [Composer](https://getcomposer.org):
 

--- a/composer.json
+++ b/composer.json
@@ -30,6 +30,7 @@
     },
     "require-dev": {
         "phpunit/phpunit": "^7.0",
-        "squizlabs/php_codesniffer": "^3.1"
+        "squizlabs/php_codesniffer": "^3.1",
+        "php-http/guzzle6-adapter": "^2.0"
     }
 }

--- a/composer.json
+++ b/composer.json
@@ -22,7 +22,11 @@
     "require": {
         "php": ">= 7.1",
         "ext-json": "*",
-        "guzzlehttp/guzzle": "~6.0"
+        "php-http/httplug": "^2.0",
+        "php-http/client-implementation": "*",
+        "php-http/discovery": "^1.4",
+        "php-http/message": "^1.7",
+        "psr/http-message": "^1.0"
     },
     "require-dev": {
         "phpunit/phpunit": "^7.0",

--- a/composer.json
+++ b/composer.json
@@ -22,7 +22,7 @@
     "require": {
         "php": ">= 7.1",
         "ext-json": "*",
-        "php-http/httplug": "^2.0",
+        "php-http/httplug": "^1.0 || ^2.0",
         "php-http/client-implementation": "*",
         "php-http/discovery": "^1.4",
         "php-http/message": "^1.7",

--- a/src/IntercomAdmins.php
+++ b/src/IntercomAdmins.php
@@ -2,6 +2,8 @@
 
 namespace Intercom;
 
+use Http\Client\Exception;
+
 class IntercomAdmins
 {
 
@@ -25,8 +27,8 @@ class IntercomAdmins
      *
      * @see    https://developers.intercom.io/reference#list-admins
      * @param  array $options
-     * @return mixed
-     * @throws \GuzzleHttp\Exception\GuzzleException
+     * @return stdClass
+     * @throws Exception
      */
     public function getAdmins($options = [])
     {
@@ -39,8 +41,8 @@ class IntercomAdmins
      * @see    https://developers.intercom.com/v2.0/reference#view-an-admin
      * @param  integer $id
      * @param  array   $options
-     * @return mixed
-     * @throws \GuzzleHttp\Exception\GuzzleException
+     * @return stdClass
+     * @throws Exception
      */
     public function getAdmin($id, $options = [])
     {

--- a/src/IntercomBulk.php
+++ b/src/IntercomBulk.php
@@ -2,6 +2,8 @@
 
 namespace Intercom;
 
+use Http\Client\Exception;
+
 class IntercomBulk
 {
 
@@ -24,8 +26,8 @@ class IntercomBulk
      * Creates Users in bulk.
      *
      * @param  array $options
-     * @return mixed
-     * @throws \GuzzleHttp\Exception\GuzzleException
+     * @return stdClass
+     * @throws Exception
      */
     public function users($options)
     {
@@ -36,8 +38,8 @@ class IntercomBulk
      * Creates Events in bulk.
      *
      * @param  array $options
-     * @return mixed
-     * @throws \GuzzleHttp\Exception\GuzzleException
+     * @return stdClass
+     * @throws Exception
      */
     public function events($options)
     {

--- a/src/IntercomClient.php
+++ b/src/IntercomClient.php
@@ -144,6 +144,10 @@ class IntercomClient
         $this->appIdOrToken = $appIdOrToken;
         $this->passwordPart = $password;
         $this->extraRequestHeaders = $extraRequestHeaders;
+
+        $this->client = HttpClientDiscovery::find();
+        $this->requestFactory = MessageFactoryDiscovery::find();
+        $this->uriFactory = UriFactoryDiscovery::find();
     }
 
     /**
@@ -224,7 +228,7 @@ class IntercomClient
      */
     public function get($endpoint, $queryParams = [])
     {
-        $uri = $this->getUriFactory()->createUri("https://api.intercom.io/$endpoint");
+        $uri = $this->uriFactory->createUri("https://api.intercom.io/$endpoint");
         if (!empty($queryParams)) {
             $uri = $uri->withQuery(http_build_query($queryParams));
         }
@@ -271,39 +275,6 @@ class IntercomClient
     }
 
     /**
-     * @return ClientInterface
-     */
-    private function getClient()
-    {
-        if (empty($this->client)) {
-            $this->client = HttpClientDiscovery::find();
-        }
-        return $this->client;
-    }
-
-    /**
-     * @return RequestFactory
-     */
-    private function getRequestFactory()
-    {
-        if (empty($this->requestFactory)) {
-            $this->requestFactory = MessageFactoryDiscovery::find();
-        }
-        return $this->requestFactory;
-    }
-
-    /**
-     * @return UriFactory
-     */
-    private function getUriFactory()
-    {
-        if (empty($this->uriFactory)) {
-            $this->uriFactory = UriFactoryDiscovery::find();
-        }
-        return $this->uriFactory;
-    }
-
-    /**
      * Returns authentication parameters
      *
      * @return Authentication
@@ -341,10 +312,10 @@ class IntercomClient
     {
         $headers = $this->getRequestHeaders();
         $request = $this->authenticateRequest(
-            $this->getRequestFactory()->createRequest($method, $uri, $headers, $body)
+            $this->requestFactory->createRequest($method, $uri, $headers, $body)
         );
 
-        return $this->getClient()->sendRequest($request);
+        return $this->client->sendRequest($request);
     }
 
     /**

--- a/src/IntercomClient.php
+++ b/src/IntercomClient.php
@@ -19,9 +19,9 @@ use Psr\Http\Message\UriInterface;
 class IntercomClient
 {
     /**
-     * @var ClientInterface $client
+     * @var ClientInterface $httpClient
      */
-    private $client;
+    private $httpClient;
 
     /**
      * @var RequestFactory $requestFactory
@@ -145,7 +145,7 @@ class IntercomClient
         $this->passwordPart = $password;
         $this->extraRequestHeaders = $extraRequestHeaders;
 
-        $this->client = HttpClientDiscovery::find();
+        $this->httpClient = HttpClientDiscovery::find();
         $this->requestFactory = MessageFactoryDiscovery::find();
         $this->uriFactory = UriFactoryDiscovery::find();
     }
@@ -153,11 +153,11 @@ class IntercomClient
     /**
      * Sets the HTTP client.
      *
-     * @param ClientInterface $client
+     * @param ClientInterface $httpClient
      */
-    public function setClient(ClientInterface $client)
+    public function setHttpClient(ClientInterface $httpClient)
     {
-        $this->client = $client;
+        $this->httpClient = $httpClient;
     }
 
     /**
@@ -316,7 +316,7 @@ class IntercomClient
             $this->requestFactory->createRequest($method, $uri, $headers, $body)
         );
 
-        return $this->client->sendRequest($request);
+        return $this->httpClient->sendRequest($request);
     }
 
     /**

--- a/src/IntercomClient.php
+++ b/src/IntercomClient.php
@@ -303,7 +303,7 @@ class IntercomClient
     /**
      * @param string              $method
      * @param string|UriInterface $uri
-     * @param array|null          $body
+     * @param array|string|null   $body
      *
      * @return ResponseInterface
      * @throws ClientExceptionInterface
@@ -311,6 +311,7 @@ class IntercomClient
     private function sendRequest($method, $uri, $body = null)
     {
         $headers = $this->getRequestHeaders();
+        $body = ($body !== null && is_array($body)) ? json_encode($body) : $body;
         $request = $this->authenticateRequest(
             $this->requestFactory->createRequest($method, $uri, $headers, $body)
         );

--- a/src/IntercomClient.php
+++ b/src/IntercomClient.php
@@ -2,31 +2,51 @@
 
 namespace Intercom;
 
-use GuzzleHttp\Client;
-use GuzzleHttp\Psr7\Response;
+use Http\Discovery\HttpClientDiscovery;
+use Http\Discovery\MessageFactoryDiscovery;
+use Http\Discovery\UriFactoryDiscovery;
+use Http\Message\Authentication;
+use Http\Message\Authentication\BasicAuth;
+use Http\Message\Authentication\Bearer;
+use Http\Message\RequestFactory;
+use Http\Message\UriFactory;
+use Psr\Http\Client\ClientExceptionInterface;
+use Psr\Http\Client\ClientInterface;
+use Psr\Http\Message\RequestInterface;
+use Psr\Http\Message\ResponseInterface;
+use Psr\Http\Message\UriInterface;
 
 class IntercomClient
 {
+    /**
+     * @var ClientInterface $client
+     */
+    private $client;
 
     /**
-     * @var Client $http_client
+     * @var RequestFactory $requestFactory
      */
-    private $http_client;
+    private $requestFactory;
+
+    /**
+     * @var UriFactory $uriFactory
+     */
+    private $uriFactory;
 
     /**
      * @var string API user authentication
      */
-    protected $usernamePart;
+    private $usernameOrToken;
 
     /**
      * @var string API password authentication
      */
-    protected $passwordPart;
+    private $password;
 
     /**
-     * @var string Extra Guzzle Requests Options
+     * @var array $extraRequestHeaders
      */
-    protected $extraGuzzleRequestsOptions;
+    private $extraRequestHeaders;
 
     /**
      * @var IntercomUsers $users
@@ -94,20 +114,19 @@ class IntercomClient
     public $notes;
 
     /**
-     * @var int[] $rateLimitDetails
+     * @var array $rateLimitDetails
      */
     protected $rateLimitDetails = [];
 
     /**
      * IntercomClient constructor.
      *
-     * @param string $usernamePart App ID.
-     * @param string|null $passwordPart Api Key.
-     * @param array  $extraGuzzleRequestsOptions Extra Guzzle request options.
+     * @param string $appIdOrToken App ID.
+     * @param string|null $password Api Key.
+     * @param array $extraRequestHeaders Extra request headers to be sent in every api request
      */
-    public function __construct($usernamePart, $passwordPart, $extraGuzzleRequestsOptions = [])
+    public function __construct($appIdOrToken, $password = null, $extraRequestHeaders = [])
     {
-        $this->setDefaultClient();
         $this->users = new IntercomUsers($this);
         $this->events = new IntercomEvents($this);
         $this->companies = new IntercomCompanies($this);
@@ -122,24 +141,39 @@ class IntercomClient
         $this->bulk = new IntercomBulk($this);
         $this->notes = new IntercomNotes($this);
 
-        $this->usernamePart = $usernamePart;
-        $this->passwordPart = $passwordPart;
-        $this->extraGuzzleRequestsOptions = $extraGuzzleRequestsOptions;
-    }
-
-    private function setDefaultClient()
-    {
-        $this->http_client = new Client();
+        $this->appIdOrToken = $appIdOrToken;
+        $this->passwordPart = $password;
+        $this->extraRequestHeaders = $extraRequestHeaders;
     }
 
     /**
-     * Sets GuzzleHttp client.
+     * Sets the HTTP client.
      *
-     * @param Client $client
+     * @param ClientInterface $client
      */
-    public function setClient($client)
+    public function setClient(ClientInterface $client)
     {
-        $this->http_client = $client;
+        $this->client = $client;
+    }
+
+    /**
+     * Sets the request factory.
+     *
+     * @param RequestFactory $requestFactory
+     */
+    public function setRequestFactory(RequestFactory $requestFactory)
+    {
+        $this->requestFactory = $requestFactory;
+    }
+
+    /**
+     * Sets the URI factory.
+     *
+     * @param UriFactory $uriFactory
+     */
+    public function setUriFactory(UriFactory $uriFactory)
+    {
+        $this->uriFactory = $uriFactory;
     }
 
     /**
@@ -147,19 +181,11 @@ class IntercomClient
      *
      * @param  string $endpoint
      * @param  array $json
-     * @return mixed
-     * @throws \GuzzleHttp\Exception\GuzzleException
+     * @return stdClass
      */
     public function post($endpoint, $json)
     {
-        $guzzleRequestOptions = $this->getGuzzleRequestOptions([
-            'json' => $json,
-            'auth' => $this->getAuth(),
-            'headers' => [
-                'Accept' => 'application/json'
-            ],
-        ]);
-        $response = $this->http_client->request('POST', "https://api.intercom.io/$endpoint", $guzzleRequestOptions);
+        $response = $this->sendRequest('POST', "https://api.intercom.io/$endpoint", $json);
         return $this->handleResponse($response);
     }
 
@@ -168,20 +194,11 @@ class IntercomClient
      *
      * @param  string $endpoint
      * @param  array $json
-     * @return mixed
-     * @throws \GuzzleHttp\Exception\GuzzleException
+     * @return stdClass
      */
     public function put($endpoint, $json)
     {
-        $guzzleRequestOptions = $this->getGuzzleRequestOptions([
-            'json' => $json,
-            'auth' => $this->getAuth(),
-            'headers' => [
-                'Accept' => 'application/json'
-            ],
-        ]);
-
-        $response = $this->http_client->request('PUT', "https://api.intercom.io/$endpoint", $guzzleRequestOptions);
+        $response = $this->sendRequest('PUT', "https://api.intercom.io/$endpoint", $json);
         return $this->handleResponse($response);
     }
 
@@ -190,108 +207,164 @@ class IntercomClient
      *
      * @param  string $endpoint
      * @param  array $json
-     * @return mixed
-     * @throws \GuzzleHttp\Exception\GuzzleException
+     * @return stdClass
      */
     public function delete($endpoint, $json)
     {
-        $guzzleRequestOptions = $this->getGuzzleRequestOptions(
-            [
-            'json' => $json,
-            'auth' => $this->getAuth(),
-            'headers' => [
-                'Accept' => 'application/json'
-            ],
-            ]
-        );
-
-        $response = $this->http_client->request('DELETE', "https://api.intercom.io/$endpoint", $guzzleRequestOptions);
+        $response = $this->sendRequest('DELETE', "https://api.intercom.io/$endpoint", $json);
         return $this->handleResponse($response);
     }
 
     /**
-     * @param string $endpoint
-     * @param array  $query
-     * @return mixed
-     * @throws \GuzzleHttp\Exception\GuzzleException
-     */
-    public function get($endpoint, $query)
-    {
-        $guzzleRequestOptions = $this->getGuzzleRequestOptions(
-            [
-            'query' => $query,
-            'auth' => $this->getAuth(),
-            'headers' => [
-                'Accept' => 'application/json'
-            ],
-            ]
-        );
-
-        $response = $this->http_client->request('GET', "https://api.intercom.io/$endpoint", $guzzleRequestOptions);
-        return $this->handleResponse($response);
-    }
-
-    /**
-     * Returns next page of the result.
+     * Sends GET request to Intercom API.
      *
-     * @param  \stdClass $pages
-     * @return mixed
-     * @throws \GuzzleHttp\Exception\GuzzleException
+     * @param string $endpoint
+     * @param array  $queryParams
+     * @return stdClass
+     */
+    public function get($endpoint, $queryParams = [])
+    {
+        $uri = $this->getUriFactory()->createUri("https://api.intercom.io/$endpoint");
+        if (!empty($queryParams)) {
+            $uri = $uri->withQuery(http_build_query($queryParams));
+        }
+
+        $response = $this->sendRequest('GET', $uri);
+
+        return $this->handleResponse($response);
+    }
+
+    /**
+     * Returns the next page of the result.
+     *
+     * @param  stdClass $pages
+     * @return stdClass
      */
     public function nextPage($pages)
     {
-        $guzzleRequestOptions = $this->getGuzzleRequestOptions(
-            [
-            'auth' => $this->getAuth(),
-            'headers' => [
-                'Accept' => 'application/json'
-            ],
-            ]
-        );
-
-        $response = $this->http_client->request('GET', $pages->next, $guzzleRequestOptions);
+        $response = $this->sendRequest('GET', $pages->next);
         return $this->handleResponse($response);
     }
 
     /**
-     * Returns Guzzle Requests Options Array
-     *
-     * @param  array $defaultGuzzleRequestOptions
-     * @return array
-     */
-    public function getGuzzleRequestOptions($defaultGuzzleRequestOptions = [])
-    {
-        return array_replace_recursive($this->extraGuzzleRequestsOptions, $defaultGuzzleRequestOptions);
-    }
-
-    /**
-     * Returns authentication parameters.
+     * Gets the rate limit details.
      *
      * @return array
      */
-    public function getAuth()
+    public function getRateLimitDetails()
     {
-        return [$this->usernamePart, $this->passwordPart];
+        return $this->rateLimitDetails;
     }
 
     /**
-     * @param Response $response
-     * @return mixed
+     * @return array
      */
-    private function handleResponse(Response $response)
+    private function getRequestHeaders()
+    {
+        return array_merge(
+            [
+                'Accept' => 'application/json',
+                'Content-Type' => 'application/json'
+            ],
+            $this->extraRequestHeaders
+        );
+    }
+
+    /**
+     * @return ClientInterface
+     */
+    private function getClient()
+    {
+        if (empty($this->client)) {
+            $this->client = HttpClientDiscovery::find();
+        }
+        return $this->client;
+    }
+
+    /**
+     * @return RequestFactory
+     */
+    private function getRequestFactory()
+    {
+        if (empty($this->requestFactory)) {
+            $this->requestFactory = MessageFactoryDiscovery::find();
+        }
+        return $this->requestFactory;
+    }
+
+    /**
+     * @return UriFactory
+     */
+    private function getUriFactory()
+    {
+        if (empty($this->uriFactory)) {
+            $this->uriFactory = UriFactoryDiscovery::find();
+        }
+        return $this->uriFactory;
+    }
+
+    /**
+     * Returns authentication parameters
+     *
+     * @return Authentication
+     */
+    private function getAuth()
+    {
+        if (!empty($this->appIdOrToken) && !empty($this->passwordPart)) {
+            return new BasicAuth($this->appIdOrToken, $this->passwordPart);
+        } elseif (!empty($this->appIdOrToken)) {
+            return new Bearer($this->appIdOrToken);
+        }
+        return null;
+    }
+
+    /**
+     * Authenticates a request object
+     * @param RequestInterface $request
+     *
+     * @return RequestInterface
+     */
+    private function authenticateRequest(RequestInterface $request)
+    {
+        return $this->getAuth() ? $this->getAuth()->authenticate($request) : $request;
+    }
+
+    /**
+     * @param string              $method
+     * @param string|UriInterface $uri
+     * @param array|null          $body
+     *
+     * @return ResponseInterface
+     * @throws ClientExceptionInterface
+     */
+    private function sendRequest($method, $uri, $body = null)
+    {
+        $headers = $this->getRequestHeaders();
+        $request = $this->authenticateRequest(
+            $this->getRequestFactory()->createRequest($method, $uri, $headers, $body)
+        );
+
+        return $this->getClient()->sendRequest($request);
+    }
+
+    /**
+     * @param ResponseInterface $response
+     *
+     * @return stdClass
+     */
+    private function handleResponse(ResponseInterface $response)
     {
         $this->setRateLimitDetails($response);
 
-        $stream = \GuzzleHttp\Psr7\stream_for($response->getBody());
-        $data = json_decode($stream);
-        return $data;
+        $stream = $response->getBody()->getContents();
+
+        return json_decode($stream);
     }
 
     /**
-     * @param Response $response
-     * @return void
+     * @param ResponseInterface $response
      */
-    private function setRateLimitDetails(Response $response)
+    private function setRateLimitDetails(ResponseInterface $response)
     {
         $this->rateLimitDetails = [
             'limit' => $response->hasHeader('X-RateLimit-Limit')
@@ -304,13 +377,5 @@ class IntercomClient
                 ? (new \DateTimeImmutable())->setTimestamp((int)$response->getHeader('X-RateLimit-Reset')[0])
                 : null,
         ];
-    }
-
-    /**
-     * @return int[]
-     */
-    public function getRateLimitDetails()
-    {
-        return $this->rateLimitDetails;
     }
 }

--- a/src/IntercomClient.php
+++ b/src/IntercomClient.php
@@ -297,7 +297,8 @@ class IntercomClient
      */
     private function authenticateRequest(RequestInterface $request)
     {
-        return $this->getAuth() ? $this->getAuth()->authenticate($request) : $request;
+        $auth = $this->getAuth();
+        return $auth ? $auth->authenticate($request) : $request;
     }
 
     /**
@@ -311,7 +312,7 @@ class IntercomClient
     private function sendRequest($method, $uri, $body = null)
     {
         $headers = $this->getRequestHeaders();
-        $body = ($body !== null && is_array($body)) ? json_encode($body) : $body;
+        $body = is_array($body) ? json_encode($body) : $body;
         $request = $this->authenticateRequest(
             $this->requestFactory->createRequest($method, $uri, $headers, $body)
         );

--- a/src/IntercomCompanies.php
+++ b/src/IntercomCompanies.php
@@ -2,6 +2,8 @@
 
 namespace Intercom;
 
+use Http\Client\Exception;
+
 class IntercomCompanies
 {
 
@@ -25,8 +27,8 @@ class IntercomCompanies
      *
      * @see    https://developers.intercom.io/reference#create-or-update-company
      * @param  array $options
-     * @return mixed
-     * @throws \GuzzleHttp\Exception\GuzzleException
+     * @return stdClass
+     * @throws Exception
      */
     public function create($options)
     {
@@ -38,8 +40,8 @@ class IntercomCompanies
      *
      * @see    https://developers.intercom.io/reference#create-or-update-company
      * @param  array $options
-     * @return mixed
-     * @throws \GuzzleHttp\Exception\GuzzleException
+     * @return stdClass
+     * @throws Exception
      */
     public function update($options)
     {
@@ -51,8 +53,8 @@ class IntercomCompanies
      *
      * @see    https://developers.intercom.io/reference#list-companies
      * @param  array $options
-     * @return mixed
-     * @throws \GuzzleHttp\Exception\GuzzleException
+     * @return stdClass
+     * @throws Exception
      */
     public function getCompanies($options)
     {
@@ -65,8 +67,8 @@ class IntercomCompanies
      * @see    https://developers.intercom.com/reference#view-a-company
      * @param  string $id
      * @param  array  $options
-     * @return mixed
-     * @throws \GuzzleHttp\Exception\GuzzleException
+     * @return stdClass
+     * @throws Exception
      */
     public function getCompany($id, $options = [])
     {

--- a/src/IntercomConversations.php
+++ b/src/IntercomConversations.php
@@ -2,6 +2,8 @@
 
 namespace Intercom;
 
+use Http\Client\Exception;
+
 class IntercomConversations
 {
 
@@ -25,8 +27,8 @@ class IntercomConversations
      *
      * @see    https://developers.intercom.io/reference#list-conversations
      * @param  array $options
-     * @return mixed
-     * @throws \GuzzleHttp\Exception\GuzzleException
+     * @return stdClass
+     * @throws Exception
      */
     public function getConversations($options)
     {
@@ -39,8 +41,8 @@ class IntercomConversations
      * @see    https://developers.intercom.io/reference#get-a-single-conversation
      * @param  string $id
      * @param  array  $options
-     * @return mixed
-     * @throws \GuzzleHttp\Exception\GuzzleException
+     * @return stdClass
+     * @throws Exception
      */
     public function getConversation($id, $options = [])
     {
@@ -54,8 +56,8 @@ class IntercomConversations
      * @see    https://developers.intercom.io/reference#replying-to-a-conversation
      * @param  string $id
      * @param  array  $options
-     * @return mixed
-     * @throws \GuzzleHttp\Exception\GuzzleException
+     * @return stdClass
+     * @throws Exception
      */
     public function replyToConversation($id, $options)
     {
@@ -68,8 +70,8 @@ class IntercomConversations
      *
      * @see    https://developers.intercom.io/reference#replying-to-users-last-conversation
      * @param  array $options
-     * @return mixed
-     * @throws \GuzzleHttp\Exception\GuzzleException
+     * @return stdClass
+     * @throws Exception
      */
     public function replyToLastConversation($options)
     {
@@ -82,8 +84,8 @@ class IntercomConversations
      *
      * @see    https://developers.intercom.io/reference#marking-a-conversation-as-read
      * @param  string $id
-     * @return mixed
-     * @throws \GuzzleHttp\Exception\GuzzleException
+     * @return stdClass
+     * @throws Exception
      */
     public function markConversationAsRead($id)
     {

--- a/src/IntercomCounts.php
+++ b/src/IntercomCounts.php
@@ -2,6 +2,8 @@
 
 namespace Intercom;
 
+use Http\Client\Exception;
+
 class IntercomCounts
 {
 
@@ -25,8 +27,8 @@ class IntercomCounts
      *
      * @see    https://developers.intercom.io/reference#getting-counts
      * @param  array $options
-     * @return mixed
-     * @throws \GuzzleHttp\Exception\GuzzleException
+     * @return stdClass
+     * @throws Exception
      */
     public function getCounts($options = [])
     {

--- a/src/IntercomEvents.php
+++ b/src/IntercomEvents.php
@@ -2,6 +2,8 @@
 
 namespace Intercom;
 
+use Http\Client\Exception;
+
 class IntercomEvents
 {
 
@@ -25,8 +27,8 @@ class IntercomEvents
      *
      * @see    https://developers.intercom.io/reference#submitting-events
      * @param  array $options
-     * @return mixed
-     * @throws \GuzzleHttp\Exception\GuzzleException
+     * @return stdClass
+     * @throws Exception
      */
     public function create($options)
     {
@@ -38,8 +40,8 @@ class IntercomEvents
      *
      * @see    https://developers.intercom.io/reference#list-user-events
      * @param  array $options
-     * @return mixed
-     * @throws \GuzzleHttp\Exception\GuzzleException
+     * @return stdClass
+     * @throws Exception
      */
     public function getEvents($options)
     {

--- a/src/IntercomLeads.php
+++ b/src/IntercomLeads.php
@@ -2,6 +2,8 @@
 
 namespace Intercom;
 
+use Http\Client\Exception;
+
 class IntercomLeads
 {
 
@@ -25,8 +27,8 @@ class IntercomLeads
      *
      * @see    https://developers.intercom.io/reference#create-lead
      * @param  array $options
-     * @return mixed
-     * @throws \GuzzleHttp\Exception\GuzzleException
+     * @return stdClass
+     * @throws Exception
      */
     public function create($options)
     {
@@ -38,8 +40,8 @@ class IntercomLeads
      *
      * @see    https://developers.intercom.io/reference#create-lead
      * @param  array $options
-     * @return mixed
-     * @throws \GuzzleHttp\Exception\GuzzleException
+     * @return stdClass
+     * @throws Exception
      */
     public function update($options)
     {
@@ -51,8 +53,8 @@ class IntercomLeads
      *
      * @see    https://developers.intercom.io/reference#list-leads
      * @param  array $options
-     * @return mixed
-     * @throws \GuzzleHttp\Exception\GuzzleException
+     * @return stdClass
+     * @throws Exception
      */
     public function getLeads($options)
     {
@@ -65,8 +67,8 @@ class IntercomLeads
      * @see    https://developers.intercom.io/reference#view-a-lead
      * @param  string $id
      * @param  array  $options
-     * @return mixed
-     * @throws \GuzzleHttp\Exception\GuzzleException
+     * @return stdClass
+     * @throws Exception
      */
     public function getLead($id, $options = [])
     {
@@ -80,8 +82,8 @@ class IntercomLeads
      * @see    https://developers.intercom.io/reference#delete-a-lead
      * @param  string $id
      * @param  array  $options
-     * @return mixed
-     * @throws \GuzzleHttp\Exception\GuzzleException
+     * @return stdClass
+     * @throws Exception
      */
     public function deleteLead($id, $options = [])
     {
@@ -94,8 +96,8 @@ class IntercomLeads
      *
      * @see    https://developers.intercom.io/reference#convert-a-lead
      * @param  $options
-     * @return mixed
-     * @throws \GuzzleHttp\Exception\GuzzleException
+     * @return stdClass
+     * @throws Exception
      */
     public function convertLead($options)
     {
@@ -118,8 +120,8 @@ class IntercomLeads
      *
      * @see    https://developers.intercom.com/v2.0/reference#iterating-over-all-leads
      * @param  array $options
-     * @return mixed
-     * @throws \GuzzleHttp\Exception\GuzzleException
+     * @return stdClass
+     * @throws Exception
      */
     public function scrollLeads($options = [])
     {

--- a/src/IntercomMessages.php
+++ b/src/IntercomMessages.php
@@ -2,6 +2,8 @@
 
 namespace Intercom;
 
+use Http\Client\Exception;
+
 class IntercomMessages
 {
 
@@ -25,8 +27,8 @@ class IntercomMessages
      *
      * @see    https://developers.intercom.io/reference#conversations
      * @param  array $options
-     * @return mixed
-     * @throws \GuzzleHttp\Exception\GuzzleException
+     * @return stdClass
+     * @throws Exception
      */
     public function create($options)
     {

--- a/src/IntercomNotes.php
+++ b/src/IntercomNotes.php
@@ -2,6 +2,8 @@
 
 namespace Intercom;
 
+use Http\Client\Exception;
+
 class IntercomNotes
 {
 
@@ -25,8 +27,8 @@ class IntercomNotes
      *
      * @see    https://developers.intercom.io/reference#create-a-note
      * @param  array $options
-     * @return mixed
-     * @throws \GuzzleHttp\Exception\GuzzleException
+     * @return stdClass
+     * @throws Exception
      */
     public function create($options)
     {
@@ -38,8 +40,8 @@ class IntercomNotes
      *
      * @see    https://developers.intercom.io/reference#list-notes-for-a-user
      * @param  array $options
-     * @return mixed
-     * @throws \GuzzleHttp\Exception\GuzzleException
+     * @return stdClass
+     * @throws Exception
      */
     public function getNotes($options)
     {
@@ -51,8 +53,8 @@ class IntercomNotes
      *
      * @see    https://developers.intercom.io/reference#view-a-note
      * @param  string $id
-     * @return mixed
-     * @throws \GuzzleHttp\Exception\GuzzleException
+     * @return stdClass
+     * @throws Exception
      */
     public function getNote($id)
     {

--- a/src/IntercomSegments.php
+++ b/src/IntercomSegments.php
@@ -2,6 +2,8 @@
 
 namespace Intercom;
 
+use Http\Client\Exception;
+
 class IntercomSegments
 {
 
@@ -26,8 +28,8 @@ class IntercomSegments
      * @see    https://developers.intercom.com/reference#view-a-segment
      * @param  string $id
      * @param  array  $options
-     * @return mixed
-     * @throws \GuzzleHttp\Exception\GuzzleException
+     * @return stdClass
+     * @throws Exception
      */
     public function getSegment($id, array $options = [])
     {
@@ -39,8 +41,8 @@ class IntercomSegments
      *
      * @see    https://developers.intercom.com/reference#list-segments
      * @param  array $options
-     * @return mixed
-     * @throws \GuzzleHttp\Exception\GuzzleException
+     * @return stdClass
+     * @throws Exception
      */
     public function getSegments($options = [])
     {

--- a/src/IntercomTags.php
+++ b/src/IntercomTags.php
@@ -2,6 +2,8 @@
 
 namespace Intercom;
 
+use Http\Client\Exception;
+
 class IntercomTags
 {
 
@@ -25,8 +27,8 @@ class IntercomTags
      *
      * @see    https://developers.intercom.io/reference#create-and-update-tags
      * @param  array $options
-     * @return mixed
-     * @throws \GuzzleHttp\Exception\GuzzleException
+     * @return stdClass
+     * @throws Exception
      */
     public function tag($options)
     {
@@ -38,8 +40,8 @@ class IntercomTags
      *
      * @see    https://developers.intercom.io/reference#list-tags-for-an-app
      * @param  array $options
-     * @return mixed
-     * @throws \GuzzleHttp\Exception\GuzzleException
+     * @return stdClass
+     * @throws Exception
      */
     public function getTags($options = [])
     {

--- a/src/IntercomUsers.php
+++ b/src/IntercomUsers.php
@@ -2,6 +2,8 @@
 
 namespace Intercom;
 
+use Http\Client\Exception;
+
 class IntercomUsers
 {
 
@@ -25,8 +27,8 @@ class IntercomUsers
      *
      * @see    https://developers.intercom.io/reference#create-or-update-user
      * @param  array $options
-     * @return mixed
-     * @throws \GuzzleHttp\Exception\GuzzleException
+     * @return stdClass
+     * @throws Exception
      */
     public function create($options)
     {
@@ -38,8 +40,8 @@ class IntercomUsers
      *
      * @see    https://developers.intercom.io/reference#create-or-update-user
      * @param  array $options
-     * @return mixed
-     * @throws \GuzzleHttp\Exception\GuzzleException
+     * @return stdClass
+     * @throws Exception
      */
     public function update($options)
     {
@@ -51,8 +53,8 @@ class IntercomUsers
      *
      * @see    https://developers.intercom.io/reference#list-users
      * @param  array $options
-     * @return mixed
-     * @throws \GuzzleHttp\Exception\GuzzleException
+     * @return stdClass
+     * @throws Exception
      */
     public function getUsers($options)
     {
@@ -65,8 +67,8 @@ class IntercomUsers
      * @see    https://developers.intercom.com/reference#view-a-user
      * @param  string $id
      * @param  array  $options
-     * @return mixed
-     * @throws \GuzzleHttp\Exception\GuzzleException
+     * @return stdClass
+     * @throws Exception
      */
     public function getUser($id, $options = [])
     {
@@ -79,8 +81,8 @@ class IntercomUsers
      *
      * @see    https://developers.intercom.com/reference#iterating-over-all-users
      * @param  array $options
-     * @return mixed
-     * @throws \GuzzleHttp\Exception\GuzzleException
+     * @return stdClass
+     * @throws Exception
      */
     public function scrollUsers($options = [])
     {
@@ -93,8 +95,8 @@ class IntercomUsers
      * @see    https://developers.intercom.com/reference#archive-a-user
      * @param  string $id
      * @param  array  $options
-     * @return mixed
-     * @throws \GuzzleHttp\Exception\GuzzleException
+     * @return stdClass
+     * @throws Exception
      */
     public function archiveUser($id, $options = [])
     {
@@ -108,8 +110,8 @@ class IntercomUsers
      * @see    https://developers.intercom.com/reference#archive-a-user
      * @param  string $id
      * @param  array  $options
-     * @return mixed
-     * @throws \GuzzleHttp\Exception\GuzzleException
+     * @return stdClass
+     * @throws Exception
      */
     public function deleteUser($id, $options = [])
     {
@@ -121,8 +123,8 @@ class IntercomUsers
      *
      * @see   https://developers.intercom.com/reference#delete-users
      * @param string $id
-     * @return mixed
-     * @throws \GuzzleHttp\Exception\GuzzleException
+     * @return stdClass
+     * @throws Exception
      */
     public function permanentlyDeleteUser($id)
     {

--- a/src/IntercomVisitors.php
+++ b/src/IntercomVisitors.php
@@ -2,6 +2,8 @@
 
 namespace Intercom;
 
+use Http\Client\Exception;
+
 class IntercomVisitors
 {
 
@@ -25,8 +27,8 @@ class IntercomVisitors
      *
      * @see    https://developers.intercom.com/reference#update-a-visitor
      * @param  array $options
-     * @return mixed
-     * @throws \GuzzleHttp\Exception\GuzzleException
+     * @return stdClass
+     * @throws Exception
      */
     public function update($options)
     {
@@ -40,8 +42,8 @@ class IntercomVisitors
      * @see    https://developers.intercom.com/reference#view-a-visitor
      * @param  string $id
      * @param  array  $options
-     * @return mixed
-     * @throws \GuzzleHttp\Exception\GuzzleException
+     * @return stdClass
+     * @throws Exception
      */
     public function getVisitor($id, $options = [])
     {
@@ -55,8 +57,8 @@ class IntercomVisitors
      * @see    https://developers.intercom.com/reference#delete-a-visitor
      * @param  string $id
      * @param  array  $options
-     * @return mixed
-     * @throws \GuzzleHttp\Exception\GuzzleException
+     * @return stdClass
+     * @throws Exception
      */
     public function deleteVisitor($id, $options = [])
     {
@@ -69,8 +71,8 @@ class IntercomVisitors
      *
      * @see    https://developers.intercom.io/reference#convert-a-lead
      * @param  $options
-     * @return mixed
-     * @throws \GuzzleHttp\Exception\GuzzleException
+     * @return stdClass
+     * @throws Exception
      */
     public function convertVisitor($options)
     {

--- a/test/IntercomClientTest.php
+++ b/test/IntercomClientTest.php
@@ -3,8 +3,9 @@
 namespace Intercom\Test;
 
 use DateTimeImmutable;
+use Http\Adapter\Guzzle6\Client;
 use Intercom\IntercomClient;
-use GuzzleHttp\Client;
+use GuzzleHttp\Client as GuzzleClient;
 use GuzzleHttp\Handler\MockHandler;
 use GuzzleHttp\Psr7\Response;
 use GuzzleHttp\HandlerStack;
@@ -25,7 +26,7 @@ class IntercomClientTest extends TestCase
         $stack = HandlerStack::create($mock);
         $stack->push($history);
 
-        $http_client = new Client(['handler' => $stack]);
+        $http_client = new Client(new GuzzleClient(['handler' => $stack]));
 
         $client = new IntercomClient('u', 'p');
         $client->setClient($http_client);
@@ -51,9 +52,9 @@ class IntercomClientTest extends TestCase
         $stack = HandlerStack::create($mock);
         $stack->push($history);
 
-        $http_client = new Client(['handler' => $stack]);
+        $http_client = new Client(new GuzzleClient(['handler' => $stack, 'connect_timeout' => 10]));
 
-        $client = new IntercomClient('u', 'p', ['connect_timeout' => 10]);
+        $client = new IntercomClient('u', 'p');
         $client->setClient($http_client);
 
         $client->users->create([
@@ -61,11 +62,38 @@ class IntercomClientTest extends TestCase
         ]);
 
         foreach ($container as $transaction) {
-            $basic = $client->getGuzzleRequestOptions()['connect_timeout'];
-            $this->assertTrue($basic == 10);
+            $options = $transaction['options'];
+            $this->assertEquals($options['connect_timeout'], 10);
         }
     }
 
+    public function testClientWithExtraHeaders()
+    {
+        $mock = new MockHandler([
+            new Response(200, ['X-Foo' => 'Bar'], "{\"foo\":\"bar\"}")
+        ]);
+
+        $container = [];
+        $history = Middleware::history($container);
+        $stack = HandlerStack::create($mock);
+        $stack->push($history);
+
+        $http_client = new Client(new GuzzleClient(['handler' => $stack]));
+
+        $client = new IntercomClient('u', 'p', ['Custom-Header' => 'value']);
+        $client->setClient($http_client);
+
+        $client->users->create([
+            'email' => 'test@intercom.io'
+        ]);
+
+        foreach ($container as $transaction) {
+            $headers = $transaction['request']->getHeaders();
+            $this->assertEquals($headers['Accept'][0], 'application/json');
+            $this->assertEquals($headers['Content-Type'][0], 'application/json');
+            $this->assertEquals($headers['Custom-Header'][0], 'value');
+        }
+    }
 
     public function testPaginationHelper()
     {
@@ -78,7 +106,7 @@ class IntercomClientTest extends TestCase
         $stack = HandlerStack::create($mock);
         $stack->push($history);
 
-        $http_client = new Client(['handler' => $stack]);
+        $http_client = new Client(new GuzzleClient(['handler' => $stack]));
 
         $client = new IntercomClient('u', 'p');
         $client->setClient($http_client);
@@ -115,7 +143,7 @@ class IntercomClientTest extends TestCase
         $stack = HandlerStack::create($mock);
         $stack->push($history);
 
-        $http_client = new Client(['handler' => $stack]);
+        $http_client = new Client(new GuzzleClient(['handler' => $stack]));
 
         $client = new IntercomClient('u', 'p');
         $client->setClient($http_client);

--- a/test/IntercomClientTest.php
+++ b/test/IntercomClientTest.php
@@ -26,10 +26,10 @@ class IntercomClientTest extends TestCase
         $stack = HandlerStack::create($mock);
         $stack->push($history);
 
-        $http_client = new Client(new GuzzleClient(['handler' => $stack]));
+        $httpClient = new Client(new GuzzleClient(['handler' => $stack]));
 
         $client = new IntercomClient('u', 'p');
-        $client->setClient($http_client);
+        $client->setHttpClient($httpClient);
 
         $client->users->create([
             'email' => 'test@intercom.io'
@@ -52,10 +52,10 @@ class IntercomClientTest extends TestCase
         $stack = HandlerStack::create($mock);
         $stack->push($history);
 
-        $http_client = new Client(new GuzzleClient(['handler' => $stack, 'connect_timeout' => 10]));
+        $httpClient = new Client(new GuzzleClient(['handler' => $stack, 'connect_timeout' => 10]));
 
         $client = new IntercomClient('u', 'p');
-        $client->setClient($http_client);
+        $client->setHttpClient($httpClient);
 
         $client->users->create([
             'email' => 'test@intercom.io'
@@ -78,10 +78,10 @@ class IntercomClientTest extends TestCase
         $stack = HandlerStack::create($mock);
         $stack->push($history);
 
-        $http_client = new Client(new GuzzleClient(['handler' => $stack]));
+        $httpClient = new Client(new GuzzleClient(['handler' => $stack]));
 
         $client = new IntercomClient('u', 'p', ['Custom-Header' => 'value']);
-        $client->setClient($http_client);
+        $client->setHttpClient($httpClient);
 
         $client->users->create([
             'email' => 'test@intercom.io'
@@ -106,10 +106,10 @@ class IntercomClientTest extends TestCase
         $stack = HandlerStack::create($mock);
         $stack->push($history);
 
-        $http_client = new Client(new GuzzleClient(['handler' => $stack]));
+        $httpClient = new Client(new GuzzleClient(['handler' => $stack]));
 
         $client = new IntercomClient('u', 'p');
-        $client->setClient($http_client);
+        $client->setHttpClient($httpClient);
 
         $pages = new stdClass;
         $pages->next = 'https://foo.com';
@@ -143,10 +143,10 @@ class IntercomClientTest extends TestCase
         $stack = HandlerStack::create($mock);
         $stack->push($history);
 
-        $http_client = new Client(new GuzzleClient(['handler' => $stack]));
+        $httpClient = new Client(new GuzzleClient(['handler' => $stack]));
 
         $client = new IntercomClient('u', 'p');
-        $client->setClient($http_client);
+        $client->setHttpClient($httpClient);
 
         $client->users->create([
             'email' => 'test@intercom.io'


### PR DESCRIPTION
## Why?

As raised in https://github.com/intercom/intercom-php/issues/255, the restriction to use Guzzle6 is a blocker for some users, especially when using other versions of the library.

## How?

[HTTPPlug](http://httplug.io/) allows us to abstract our HTTP Client implementation, and allow the SDK users to decide which client to use. It also provides enough tooling to discover already existing clients, so unless there's an especial need, this SDK will work out of the box. If a more specific implementation is required, you can still pass your custom client using the `setClient` method.

## How to test this?

1. Update your composer.json file, so you set the version `dev-ga/http-plug`.
1. See the upgrade notes at the bottom of this PR

## What's the state of this PR?

✅ This PR has been tested and it is ready to review

## To-do

- [x] Allow HTTP Plug 1.0 and 2.0
- [x] Update tests
- [x] Write release notes

Draft release notes:

> This version introduces [HTTPPlug](https://github.com/php-http/httplug) as the HTTP Client. HTTPPlug allows this library to use any HTTP Library as long as there is a HTTPPlug adaptor for it. All major libraries are available (Guzzle5/6, CURL, Buzz and [many more](http://docs.php-http.org/en/latest/clients.html)).
> 
> Upgrade instructions:
> 1. Check if any change from the list below affects your code and update it if required.
> 1. Choose a [client implementation](http://docs.php-http.org/en/latest/clients.html) and include it to your dependencies (ie `composer require php-http/curl-client`). We recommend that you choose the adapter for the library you already use in your project. If you don't use any, `php-http/curl-client` is the most lightweight.
> 1. Upgrade your `intercom/intercom-php` dependency: `composer update intercom/intercom-php`.
> 
> Changes in this version:
> * `IntercomClient` constructor third parameter now only accepts a key-value array of request headers, that will be included in every request, eg: `new IntercomClient('token', null, ['Custom-Header' => 'value']);`. If you were passing any other options to the client (apart from headers), you will need to instantiate your own client and pass it using the `setHttpClient` method. Example:
> 
>   ```php
>   $httpClient = new Http\Adapter\Guzzle6\Client(
>       new GuzzleHttp\Client(['connect_timeout' => 5]);
>   );
>   $client = new IntercomClient('token');
>   $client->setHttpClient($httpClient); 
>   ```
> 
> * `IntercomClient` method `setClient` has been renamed to `setHttpClient`. Its first argument must be a `Psr\Http\Client\ClientInterface`. If you were using this method before upgrading, you can use the Guzzle6 adapter like in the example above. For example, `$client->setClient($guzzleClient)` would need to be changed to `$client->setHttpClient(new Http\Adapter\Guzzle6\Client($guzzleClient))`. 
> * `IntercomClient` no longer exposes the methods `getGuzzleRequestOptions` and `getAuth`.
> * `IntercomClient` now provides the methods `setRequestFactory` and `setUriFactory` so you can customize the generation of requests and URIs if needed.
> * From now on, all the exceptions thrown by the SDK will implement `Http\Client\Exception`. See the different exceptions that can be thrown [in the HTTPPlug documentation](http://docs.php-http.org/en/latest/httplug/exceptions.html)