### PR TITLE
Upgrade to PHP 7.1+

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,8 +1,8 @@
 version: 2
 jobs:
-  build:
+  test-7.3: &test-template
     docker:
-      - image: circleci/php:5.6
+      - image: circleci/php:7.3
 
     working_directory: ~/intercom-php
 
@@ -11,3 +11,21 @@ jobs:
       - run: composer install --no-interaction
       - run: vendor/bin/phpunit
       - run: vendor/bin/phpcs --standard=PSR2 src test
+
+  test-7.2:
+    <<: *test-template
+    docker:
+      - image: circleci/php:7.2
+
+  test-7.1:
+    <<: *test-template
+    docker:
+      - image: circleci/php:7.1
+
+workflows:
+  version: 2
+  test_on_supported_php_versions:
+    jobs:
+      - test-7.3
+      - test-7.2
+      - test-7.1

--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@ Official PHP bindings to the Intercom API
 
 ## Installation
 
-This library supports PHP 7.3, 7.2 and 7.1.
+This library supports PHP 7.1 and later
 
 The recommended way to install intercom-php is through [Composer](https://getcomposer.org):
 

--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@ Official PHP bindings to the Intercom API
 
 ## Installation
 
-Requires PHP 5.6.
+This library supports PHP 7.3, 7.2 and 7.1.
 
 The recommended way to install intercom-php is through [Composer](https://getcomposer.org):
 

--- a/composer.json
+++ b/composer.json
@@ -20,12 +20,12 @@
         }
     },
     "require": {
-        "php": ">= 5.6",
+        "php": ">= 7.1",
         "ext-json": "*",
         "guzzlehttp/guzzle": "~6.0"
     },
     "require-dev": {
-        "phpunit/phpunit": "4.0.*",
+        "phpunit/phpunit": "^7.0",
         "squizlabs/php_codesniffer": "^3.1"
     }
 }

--- a/phpunit.xml
+++ b/phpunit.xml
@@ -7,8 +7,7 @@
          convertNoticesToExceptions="true"
          convertWarningsToExceptions="true"
          processIsolation="false"
-         stopOnFailure="false"
-         syntaxCheck="false">
+         stopOnFailure="false">
     <testsuites>
         <testsuite name="Intercom Test Suite">
             <directory suffix=".php">./test/</directory>

--- a/test/IntercomAdminsTest.php
+++ b/test/IntercomAdminsTest.php
@@ -3,9 +3,9 @@
 namespace Intercom\Test;
 
 use Intercom\IntercomAdmins;
-use PHPUnit_Framework_TestCase;
+use PHPUnit\Framework\TestCase;
 
-class IntercomAdminsTest extends PHPUnit_Framework_TestCase
+class IntercomAdminsTest extends TestCase
 {
     public function testAdminsList()
     {

--- a/test/IntercomBulkTest.php
+++ b/test/IntercomBulkTest.php
@@ -3,9 +3,9 @@
 namespace Intercom\Test;
 
 use Intercom\IntercomBulk;
-use PHPUnit_Framework_TestCase;
+use PHPUnit\Framework\TestCase;
 
-class IntercomBulkTest extends PHPUnit_Framework_TestCase
+class IntercomBulkTest extends TestCase
 {
     public function testBulkUsers()
     {

--- a/test/IntercomClientTest.php
+++ b/test/IntercomClientTest.php
@@ -9,10 +9,10 @@ use GuzzleHttp\Handler\MockHandler;
 use GuzzleHttp\Psr7\Response;
 use GuzzleHttp\HandlerStack;
 use GuzzleHttp\Middleware;
-use PHPUnit_Framework_TestCase;
+use PHPUnit\Framework\TestCase;
 use stdClass;
 
-class IntercomClientTest extends PHPUnit_Framework_TestCase
+class IntercomClientTest extends TestCase
 {
     public function testBasicClient()
     {

--- a/test/IntercomCompaniesTest.php
+++ b/test/IntercomCompaniesTest.php
@@ -3,9 +3,9 @@
 namespace Intercom\Test;
 
 use Intercom\IntercomCompanies;
-use PHPUnit_Framework_TestCase;
+use PHPUnit\Framework\TestCase;
 
-class IntercomCompaniesTest extends PHPUnit_Framework_TestCase
+class IntercomCompaniesTest extends TestCase
 {
     public function testCompanyCreate()
     {

--- a/test/IntercomConversationsTest.php
+++ b/test/IntercomConversationsTest.php
@@ -3,9 +3,9 @@
 namespace Intercom\Test;
 
 use Intercom\IntercomConversations;
-use PHPUnit_Framework_TestCase;
+use PHPUnit\Framework\TestCase;
 
-class IntercomConversationsTest extends PHPUnit_Framework_TestCase
+class IntercomConversationsTest extends TestCase
 {
     public function testConversationsList()
     {

--- a/test/IntercomCountsTest.php
+++ b/test/IntercomCountsTest.php
@@ -3,9 +3,9 @@
 namespace Intercom\Test;
 
 use Intercom\IntercomCounts;
-use PHPUnit_Framework_TestCase;
+use PHPUnit\Framework\TestCase;
 
-class IntercomCountsTest extends PHPUnit_Framework_TestCase
+class IntercomCountsTest extends TestCase
 {
     public function testCountsList()
     {

--- a/test/IntercomEventsTest.php
+++ b/test/IntercomEventsTest.php
@@ -3,9 +3,9 @@
 namespace Intercom\Test;
 
 use Intercom\IntercomEvents;
-use PHPUnit_Framework_TestCase;
+use PHPUnit\Framework\TestCase;
 
-class IntercomEventsTest extends PHPUnit_Framework_TestCase
+class IntercomEventsTest extends TestCase
 {
     public function testEventCreate()
     {

--- a/test/IntercomLeadsTest.php
+++ b/test/IntercomLeadsTest.php
@@ -3,9 +3,9 @@
 namespace Intercom\Test;
 
 use Intercom\IntercomLeads;
-use PHPUnit_Framework_TestCase;
+use PHPUnit\Framework\TestCase;
 
-class IntercomLeadsTest extends PHPUnit_Framework_TestCase
+class IntercomLeadsTest extends TestCase
 {
     public function testLeadCreate()
     {

--- a/test/IntercomMessagesTest.php
+++ b/test/IntercomMessagesTest.php
@@ -3,9 +3,9 @@
 namespace Intercom\Test;
 
 use Intercom\IntercomMessages;
-use PHPUnit_Framework_TestCase;
+use PHPUnit\Framework\TestCase;
 
-class IntercomMessagesTest extends PHPUnit_Framework_TestCase
+class IntercomMessagesTest extends TestCase
 {
     public function testMessageCreate()
     {

--- a/test/IntercomNotesTest.php
+++ b/test/IntercomNotesTest.php
@@ -3,9 +3,9 @@
 namespace Intercom\Test;
 
 use Intercom\IntercomNotes;
-use PHPUnit_Framework_TestCase;
+use PHPUnit\Framework\TestCase;
 
-class IntercomNotesTest extends PHPUnit_Framework_TestCase
+class IntercomNotesTest extends TestCase
 {
     public function testNoteCreate()
     {

--- a/test/IntercomSegmentsTest.php
+++ b/test/IntercomSegmentsTest.php
@@ -3,9 +3,9 @@
 namespace Intercom\Test;
 
 use Intercom\IntercomSegments;
-use PHPUnit_Framework_TestCase;
+use PHPUnit\Framework\TestCase;
 
-class IntercomSegmentTest extends PHPUnit_Framework_TestCase
+class IntercomSegmentTest extends TestCase
 {
 
     public function testSegmentList()

--- a/test/IntercomTagsTest.php
+++ b/test/IntercomTagsTest.php
@@ -3,9 +3,9 @@
 namespace Intercom\Test;
 
 use Intercom\IntercomTags;
-use PHPUnit_Framework_TestCase;
+use PHPUnit\Framework\TestCase;
 
-class IntercomTagsTest extends PHPUnit_Framework_TestCase
+class IntercomTagsTest extends TestCase
 {
     public function testTagUsers()
     {

--- a/test/IntercomUsersTest.php
+++ b/test/IntercomUsersTest.php
@@ -3,9 +3,9 @@
 namespace Intercom\Test;
 
 use Intercom\IntercomUsers;
-use PHPUnit_Framework_TestCase;
+use PHPUnit\Framework\TestCase;
 
-class IntercomUsersTest extends PHPUnit_Framework_TestCase
+class IntercomUsersTest extends TestCase
 {
     public function testUserCreate()
     {

--- a/test/IntercomVisitorsTest.php
+++ b/test/IntercomVisitorsTest.php
@@ -3,9 +3,9 @@
 namespace Intercom\Test;
 
 use Intercom\IntercomVisitors;
-use PHPUnit_Framework_TestCase;
+use PHPUnit\Framework\TestCase;
 
-class IntercomVisitorsTest extends PHPUnit_Framework_TestCase
+class IntercomVisitorsTest extends TestCase
 {
 
     public function testVisitorUpdate()


### PR DESCRIPTION
## Why?

[PHP 5.6 and 7.0 are no longer supported](http://php.net/supported-versions.php). We should only support active versions (7.1, 7.2 and 7.3 at the time of writing)

## How?

This PR drops the support for PHP < 7.1 and splits the circle tests to ensure it works in all of those versions.

PHPUnit 4 is both unsupported and not compatible with PHP >=7.2. [PHPUnit 7 is compatible with php 7.1 to 7.3](https://phpunit.de/supported-versions.html), so I'm upgrading to that version.