### PR TITLE
Use ErrorPlugin to raise 4xx and 5xx exceptions

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ Official PHP bindings to the Intercom API
 
 This library supports PHP 7.1 and later
 
-This library uses [HTTPPlug](https://github.com/php-http/httplug) as HTTP client. HTTPPlug is an abstraction that allows this library to support many different HTTP Clients. Therefore, you need to provide it with an adapter for the HTTP library you prefer. You can find all the available adapters [in Packagist](https://packagist.org/providers/php-http/client-implementation). This documentation assumes you use the Guzzle6 Client, but you can replace it with any adapter that you prefer.
+This library uses [HTTPlug](https://github.com/php-http/httplug) as HTTP client. HTTPlug is an abstraction that allows this library to support many different HTTP Clients. Therefore, you need to provide it with an adapter for the HTTP library you prefer. You can find all the available adapters [in Packagist](https://packagist.org/providers/php-http/client-implementation). This documentation assumes you use the Guzzle6 Client, but you can replace it with any adapter that you prefer.
 
 The recommended way to install intercom-php is through [Composer](https://getcomposer.org):
 
@@ -457,7 +457,7 @@ while (!empty($resp->scroll_param) && sizeof($resp->users) > 0) {
 
 ## Exceptions
 
-Exceptions are handled by HTTPPlug. Every exception thrown implements `Http\Client\Exception`. See the different exceptions that can be thrown [in the HTTPPlug documentation](http://docs.php-http.org/en/latest/httplug/exceptions.html).
+Exceptions are handled by HTTPlug. Every exception thrown implements `Http\Client\Exception`. See the [http client exceptions](http://docs.php-http.org/en/latest/httplug/exceptions.html) and the [client and server errors](http://docs.php-http.org/en/latest/plugins/error.html).
 The Intercom API may return an unsuccessful HTTP response, for example when a resource is not found (404).
 If you want to catch errors you can wrap your API call into a try/catch block:
 

--- a/composer.json
+++ b/composer.json
@@ -26,11 +26,12 @@
         "php-http/client-implementation": "*",
         "php-http/discovery": "^1.4",
         "php-http/message": "^1.7",
-        "psr/http-message": "^1.0"
+        "psr/http-message": "^1.0",
+        "php-http/client-common": "^1.9"
     },
     "require-dev": {
         "phpunit/phpunit": "^7.0",
         "squizlabs/php_codesniffer": "^3.1",
-        "php-http/guzzle6-adapter": "^2.0"
+        "php-http/guzzle6-adapter": "^1.0 || ^2.0"
     }
 }

--- a/src/IntercomClient.php
+++ b/src/IntercomClient.php
@@ -2,6 +2,9 @@
 
 namespace Intercom;
 
+use Http\Client\Common\Plugin\ErrorPlugin;
+use Http\Client\Common\PluginClient;
+use Http\Client\HttpClient;
 use Http\Discovery\HttpClientDiscovery;
 use Http\Discovery\MessageFactoryDiscovery;
 use Http\Discovery\UriFactoryDiscovery;
@@ -11,7 +14,6 @@ use Http\Message\Authentication\Bearer;
 use Http\Message\RequestFactory;
 use Http\Message\UriFactory;
 use Psr\Http\Client\ClientExceptionInterface;
-use Psr\Http\Client\ClientInterface;
 use Psr\Http\Message\RequestInterface;
 use Psr\Http\Message\ResponseInterface;
 use Psr\Http\Message\UriInterface;
@@ -19,7 +21,7 @@ use Psr\Http\Message\UriInterface;
 class IntercomClient
 {
     /**
-     * @var ClientInterface $httpClient
+     * @var HttpClient $httpClient
      */
     private $httpClient;
 
@@ -145,7 +147,7 @@ class IntercomClient
         $this->passwordPart = $password;
         $this->extraRequestHeaders = $extraRequestHeaders;
 
-        $this->httpClient = HttpClientDiscovery::find();
+        $this->httpClient = $this->getDefaultHttpClient();
         $this->requestFactory = MessageFactoryDiscovery::find();
         $this->uriFactory = UriFactoryDiscovery::find();
     }
@@ -153,9 +155,9 @@ class IntercomClient
     /**
      * Sets the HTTP client.
      *
-     * @param ClientInterface $httpClient
+     * @param HttpClient $httpClient
      */
-    public function setHttpClient(ClientInterface $httpClient)
+    public function setHttpClient(HttpClient $httpClient)
     {
         $this->httpClient = $httpClient;
     }
@@ -258,6 +260,17 @@ class IntercomClient
     public function getRateLimitDetails()
     {
         return $this->rateLimitDetails;
+    }
+
+    /**
+     * @return HttpClient
+     */
+    private function getDefaultHttpClient()
+    {
+        return new PluginClient(
+            HttpClientDiscovery::find(),
+            [new ErrorPlugin()]
+        );
     }
 
     /**


### PR DESCRIPTION
## Why?

The release 4.0.0 introduced an unexpected change in exception handling. HTTPlug does not throw exceptions for client/server errors (4xx/5xx) by default and it encourages creating our own exception layer.

## How?

As this intends to be a very lightweight API wrapper, we don't want to do that and we expect the exception handling to be done by the library user.

I included the ErrorPlugin so HTTPlug will start throwing exceptions when a 4xx or 5xx error occurs as it used to do in version 3.