### PR TITLE
Fix IntercomClient incorrectly named variables

### DIFF
--- a/src/IntercomClient.php
+++ b/src/IntercomClient.php
@@ -38,12 +38,12 @@ class IntercomClient
     /**
      * @var string API user authentication
      */
-    private $usernameOrToken;
+    private $appIdOrToken;
 
     /**
      * @var string API password authentication
      */
-    private $password;
+    private $passwordPart;
 
     /**
      * @var array $extraRequestHeaders


### PR DESCRIPTION
not up-to-date properties name