### PR TITLE
Make return phpDoc of stdClass fully qualified

### DIFF
--- a/src/IntercomAdmins.php
+++ b/src/IntercomAdmins.php
@@ -3,6 +3,7 @@
 namespace Intercom;
 
 use Http\Client\Exception;
+use stdClass;
 
 class IntercomAdmins
 {

--- a/src/IntercomBulk.php
+++ b/src/IntercomBulk.php
@@ -3,6 +3,7 @@
 namespace Intercom;
 
 use Http\Client\Exception;
+use stdClass;
 
 class IntercomBulk
 {

--- a/src/IntercomClient.php
+++ b/src/IntercomClient.php
@@ -17,6 +17,7 @@ use Psr\Http\Client\ClientExceptionInterface;
 use Psr\Http\Message\RequestInterface;
 use Psr\Http\Message\ResponseInterface;
 use Psr\Http\Message\UriInterface;
+use stdClass;
 
 class IntercomClient
 {

--- a/src/IntercomCompanies.php
+++ b/src/IntercomCompanies.php
@@ -3,6 +3,7 @@
 namespace Intercom;
 
 use Http\Client\Exception;
+use stdClass;
 
 class IntercomCompanies
 {

--- a/src/IntercomConversations.php
+++ b/src/IntercomConversations.php
@@ -3,6 +3,7 @@
 namespace Intercom;
 
 use Http\Client\Exception;
+use stdClass;
 
 class IntercomConversations
 {

--- a/src/IntercomCounts.php
+++ b/src/IntercomCounts.php
@@ -3,6 +3,7 @@
 namespace Intercom;
 
 use Http\Client\Exception;
+use stdClass;
 
 class IntercomCounts
 {

--- a/src/IntercomEvents.php
+++ b/src/IntercomEvents.php
@@ -3,6 +3,7 @@
 namespace Intercom;
 
 use Http\Client\Exception;
+use stdClass;
 
 class IntercomEvents
 {

--- a/src/IntercomLeads.php
+++ b/src/IntercomLeads.php
@@ -3,6 +3,7 @@
 namespace Intercom;
 
 use Http\Client\Exception;
+use stdClass;
 
 class IntercomLeads
 {

--- a/src/IntercomMessages.php
+++ b/src/IntercomMessages.php
@@ -3,6 +3,7 @@
 namespace Intercom;
 
 use Http\Client\Exception;
+use stdClass;
 
 class IntercomMessages
 {

--- a/src/IntercomNotes.php
+++ b/src/IntercomNotes.php
@@ -3,6 +3,7 @@
 namespace Intercom;
 
 use Http\Client\Exception;
+use stdClass;
 
 class IntercomNotes
 {

--- a/src/IntercomSegments.php
+++ b/src/IntercomSegments.php
@@ -3,6 +3,7 @@
 namespace Intercom;
 
 use Http\Client\Exception;
+use stdClass;
 
 class IntercomSegments
 {

--- a/src/IntercomTags.php
+++ b/src/IntercomTags.php
@@ -3,6 +3,7 @@
 namespace Intercom;
 
 use Http\Client\Exception;
+use stdClass;
 
 class IntercomTags
 {

--- a/src/IntercomUsers.php
+++ b/src/IntercomUsers.php
@@ -3,6 +3,7 @@
 namespace Intercom;
 
 use Http\Client\Exception;
+use stdClass;
 
 class IntercomUsers
 {

--- a/src/IntercomVisitors.php
+++ b/src/IntercomVisitors.php
@@ -3,6 +3,7 @@
 namespace Intercom;
 
 use Http\Client\Exception;
+use stdClass;
 
 class IntercomVisitors
 {


### PR DESCRIPTION
#### Why?
To make [PhpStan](https://github.com/phpstan/phpstan) not complain about unknown class `Intercom\stdClass`.

Example:

```
Access to property $id on an unknown class Intercom\stdClass.
```

#### How?
I've chosen just adding `\` but if you would prefer `use stdClass;` instead I can update this PR.
