### PR TITLE
Added support of version 2+ of php-http/client-common

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -27,7 +27,7 @@
         "php-http/discovery": "^1.4",
         "php-http/message": "^1.7",
         "psr/http-message": "^1.0",
-        "php-http/client-common": "^1.9"
+        "php-http/client-common": "^1.9 || ^2.0"
     },
     "require-dev": {
         "phpunit/phpunit": "^7.0",


### PR DESCRIPTION
#### Why?
Breaks compatibility with other packages requiring `php-http/client-common`

And bump version to 4.0.3 please ;)

Fixes https://github.com/intercom/intercom-php/issues/279