### PR TITLE
Fix missing closing code tag in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -181,6 +181,7 @@ $client->customers->search([
     "sort" => ["field" => "name", "order" => "ascending"],
     "pagination" => ["per_page" => 10]
 ]);
+```
 
 ## Visitors
 


### PR DESCRIPTION
Adding missing tag above visitors section so it's not inside the codeblock.