### PR TITLE
Add API Version to GitHub template

### DIFF
--- a/.github/ISSUE_TEMPLATE.md
+++ b/.github/ISSUE_TEMPLATE.md
@@ -5,6 +5,7 @@ For feature requests please contact us at team@intercom.io
 
 ## Version info
   - intercom-php version:
+  - Intercom API version:
   - PHP version:
 
 ## Expected behavior


### PR DESCRIPTION
#### Why?

It can be of tremendous help to have the Intercom API Version in the incoming issues

#### How?

Add it to the template
