### PR TITLE
Add support for teams

### DIFF
--- a/README.md
+++ b/README.md
@@ -423,6 +423,17 @@ $client->notes->getNotes([
 $client->notes->getNote("42");
 ```
 
+## Teams
+
+```php
+/** List teams */
+$client->teams->getTeams();
+
+/** Get a single Team by id */
+$client->teams->getTeam("1188");
+```
+
+
 ## Rate Limits
 
 Rate limit info is passed via the rate limit headers.

--- a/src/IntercomClient.php
+++ b/src/IntercomClient.php
@@ -122,7 +122,7 @@ class IntercomClient
     public $notes;
 
     /**
-     * @var IntercomTeams $notes
+     * @var IntercomTeams $teams
      */
     public $teams;
 

--- a/src/IntercomClient.php
+++ b/src/IntercomClient.php
@@ -122,6 +122,11 @@ class IntercomClient
     public $notes;
 
     /**
+     * @var IntercomTeams $notes
+     */
+    public $teams;
+
+    /**
      * @var array $rateLimitDetails
      */
     protected $rateLimitDetails = [];
@@ -149,6 +154,7 @@ class IntercomClient
         $this->counts = new IntercomCounts($this);
         $this->bulk = new IntercomBulk($this);
         $this->notes = new IntercomNotes($this);
+        $this->teams = new IntercomTeams($this);
 
         $this->appIdOrToken = $appIdOrToken;
         $this->passwordPart = $password;

--- a/src/IntercomTeams.php
+++ b/src/IntercomTeams.php
@@ -1,0 +1,48 @@
+<?php
+
+namespace Intercom;
+
+use Http\Client\Exception;
+use stdClass;
+
+class IntercomTeams extends IntercomResource
+{
+    /**
+     * Returns list of Teams.
+     *
+     * @see    https://developers.intercom.io/reference#list-teams
+     * @param  array $options
+     * @return stdClass
+     * @throws Exception
+     */
+    public function getTeams($options = [])
+    {
+        return $this->client->get("teams", $options);
+    }
+
+    /**
+     * Gets a single Team based on the Intercom ID.
+     *
+     * @see    https://developers.intercom.com/reference#view-a-team
+     * @param  integer $id
+     * @param  array   $options
+     * @return stdClass
+     * @throws Exception
+     */
+    public function getTeam($id, $options = [])
+    {
+        $path = $this->teamPath($id);
+        return $this->client->get($path, $options);
+    }
+
+    /**
+     * Returns endpoint path to Team with given ID.
+     *
+     * @param  string $id
+     * @return string
+     */
+    public function teamPath($id)
+    {
+        return 'teams/' . $id;
+    }
+}

--- a/test/IntercomTeamsTest.php
+++ b/test/IntercomTeamsTest.php
@@ -1,0 +1,30 @@
+<?php
+
+namespace Intercom\Test;
+
+use Intercom\IntercomTeams;
+
+class IntercomTeamsTest extends TestCase
+{
+    public function testTeamsList()
+    {
+        $this->client->method('get')->willReturn('foo');
+
+        $teams = new IntercomTeams($this->client);
+        $this->assertSame('foo', $teams->getTeams());
+    }
+
+    public function testTeamsGet()
+    {
+        $this->client->method('get')->willReturn('foo');
+
+        $teams = new IntercomTeams($this->client);
+        $this->assertSame('foo', $teams->getTeam(1));
+    }
+
+    public function testTeamsGetPath()
+    {
+        $teams = new IntercomTeams($this->client);
+        $this->assertSame('teams/1', $teams->teamPath(1));
+    }
+}


### PR DESCRIPTION
#### Why?

- Teams are not yet supported: Issue #300 

#### How?

- Added a new `IntercomTeams` resource, with two endpoints: `getTeams` and `getTeam`
- Added tests
- Updated readme file
