### PR TITLE
fixing broken Contacts update method

### DIFF
--- a/README.md
+++ b/README.md
@@ -66,7 +66,7 @@ $client->contacts->create([
 ]);
 
 /** Update a contact */
-$client->contacts->update([
+$client->contacts->update("570680a8a1bcbca8a90001b9", [
     "email" => "test@example.com",
     "custom_attributes" => ['foo' => 'bar']
 ]);

--- a/src/IntercomContacts.php
+++ b/src/IntercomContacts.php
@@ -24,13 +24,15 @@ class IntercomContacts extends IntercomResource
      * Updates a Contact.
      *
      * @see    https://developers.intercom.com/intercom-api-reference/reference#update-contact
+     * @param  string $id
      * @param  array $options
      * @return stdClass
      * @throws Exception
      */
-    public function update(array $options)
+    public function update(string $id, array $options)
     {
-        return $this->client->put("contacts", $options);
+        $path = $this->contactPath($id);
+        return $this->client->put($path, $options);
     }
 
     /**

--- a/test/IntercomContactsTest.php
+++ b/test/IntercomContactsTest.php
@@ -20,7 +20,7 @@ class IntercomContactsTest extends TestCase
         $this->client->method('put')->willReturn('foo');
 
         $contacts = new IntercomContacts($this->client);
-        $this->assertSame('foo', $contacts->update([]));
+        $this->assertSame('foo', $contacts->update('', []));
     }
 
     public function testContactsGet()


### PR DESCRIPTION
"update" should follow the same pattern as other methods like deleteContact and getContact that require "id" based on the API documentation. https://developers.intercom.com/intercom-api-reference/reference#update-contact

#### Why?
Because the update method is currently broken for Contacts.

#### How?
Adds id as a required param.
