### PR TITLE
Fix bug where handleResponse() is called twice

### DIFF
--- a/src/IntercomClient.php
+++ b/src/IntercomClient.php
@@ -284,8 +284,7 @@ class IntercomClient
                 "starting_after" => $pages->next->starting_after,
             ]
         ];
-        $response = $this->post($path, $options);
-        return $this->handleResponse($response);
+        return $this->post($path, $options);
     }
 
     /**


### PR DESCRIPTION
You'll probably want better tests here....

#### Why?
Fix a bug

#### How?
nextSearchPage ends up calling handleResponse twice.
