### PR TITLE
Fix double handleResponse() bug for nextCursorPage

### DIFF
--- a/src/IntercomClient.php
+++ b/src/IntercomClient.php
@@ -296,8 +296,7 @@ class IntercomClient
      */
     public function nextCursorPage(string $path, string $startingAfter)
     {
-        $response = $this->get($path . "?starting_after=" . $startingAfter);
-        return $this->handleResponse($response);
+        return $this->get($path . "?starting_after=" . $startingAfter);
     }
 
     /**


### PR DESCRIPTION
Solves the same issue as #318 but for the nextCursorPage method.

#### Why?
Fixing a bug.

#### How?
Remove the duplicate handleResponse() call. `get()` already calls it.
