### PR TITLE
Validate Composer configuration in CI

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -8,6 +8,7 @@ jobs:
 
     steps:
       - checkout
+      - run: composer validate --strict
       - run: composer install --no-interaction --no-suggest --prefer-dist
       - run: vendor/bin/phpunit
       - run: vendor/bin/phpcs --standard=PSR2 src test

--- a/composer.json
+++ b/composer.json
@@ -36,7 +36,7 @@
         "php": ">= 7.1",
         "ext-json": "*",
         "php-http/client-common": "^1.9 || ^2.0",
-        "php-http/client-implementation": "*",
+        "php-http/client-implementation": "^1.0",
         "php-http/discovery": "^1.4",
         "php-http/httplug": "^1.0 || ^2.0",
         "php-http/message": "^1.7",


### PR DESCRIPTION
#### Why?
As that config could be broken/invalid

#### How?
Using `composer validate`
