### PR TITLE
Use php-http/mock-client to unblock PHP8.0 upgrades

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,4 @@ composer.lock
 # PHPUnit
 phpunit.phar
 phpunit.xml
+.phpunit.result.cache

--- a/composer.json
+++ b/composer.json
@@ -43,33 +43,11 @@
         "psr/http-message": "^1.0"
     },
     "require-dev": {
-        "meta/guzzle-adapter": "^6.0 || ^7.0",
+        "guzzlehttp/psr7": "^1.7.0",
+        "php-http/mock-client": "^1.4",
         "phpunit/phpunit": "^7.5 || ^8.5 || ^9.3",
         "squizlabs/php_codesniffer": "^3.1"
     },
-    "repositories": [
-        {
-            "type": "package",
-            "package": [
-                {
-                    "name": "meta/guzzle-adapter",
-                    "version": "7.0",
-                    "type": "metapackage",
-                    "require": {
-                        "php-http/guzzle7-adapter": "^0.1.1"
-                    }
-                },
-                {
-                    "name": "meta/guzzle-adapter",
-                    "version": "6.0",
-                    "type": "metapackage",
-                    "require": {
-                        "php-http/guzzle6-adapter": "^1.0 || ^2.0"
-                    }
-                }
-            ]
-        }
-    ],
     "config": {
         "sort-packages": true
     }

--- a/composer.json
+++ b/composer.json
@@ -43,10 +43,33 @@
         "psr/http-message": "^1.0"
     },
     "require-dev": {
-        "php-http/guzzle6-adapter": "^1.0 || ^2.0",
-        "phpunit/phpunit": "^7.0",
+        "meta/guzzle-adapter": "^6.0 || ^7.0",
+        "phpunit/phpunit": "^7.5 || ^8.5 || ^9.3",
         "squizlabs/php_codesniffer": "^3.1"
     },
+    "repositories": [
+        {
+            "type": "package",
+            "package": [
+                {
+                    "name": "meta/guzzle-adapter",
+                    "version": "7.0",
+                    "type": "metapackage",
+                    "require": {
+                        "php-http/guzzle7-adapter": "^0.1.1"
+                    }
+                },
+                {
+                    "name": "meta/guzzle-adapter",
+                    "version": "6.0",
+                    "type": "metapackage",
+                    "require": {
+                        "php-http/guzzle6-adapter": "^1.0 || ^2.0"
+                    }
+                }
+            ]
+        }
+    ],
     "config": {
         "sort-packages": true
     }

--- a/tests/IntercomClientTest.php
+++ b/tests/IntercomClientTest.php
@@ -3,55 +3,29 @@
 namespace Intercom\Test;
 
 use DateTimeImmutable;
-use GuzzleHttp\Client as GuzzleClient;
-use GuzzleHttp\Handler\MockHandler;
-use GuzzleHttp\HandlerStack;
-use GuzzleHttp\Middleware;
 use GuzzleHttp\Psr7\Response;
+use Http\Client\Common\Plugin\ErrorPlugin;
+use Http\Client\Common\PluginClient;
 use Http\Client\Exception;
+use Http\Discovery\HttpClientDiscovery;
+use Http\Discovery\Strategy\MockClientStrategy;
+use Http\Mock\Client;
 use Intercom\IntercomClient;
 use stdClass;
 
 class IntercomClientTest extends TestCase
 {
-    public function testBasicClient()
+    protected function setUp(): void
     {
-        $mock = new MockHandler([
-            new Response(200, ['X-Foo' => 'Bar'], "{\"foo\":\"bar\"}")
-        ]);
-
-        $container = [];
-        $history = Middleware::history($container);
-        $stack = HandlerStack::create($mock);
-        $stack->push($history);
-
-        $httpClient = $this->httpClient(new GuzzleClient(['handler' => $stack]));
-
-        $client = new IntercomClient('u', 'p');
-        $client->setHttpClient($httpClient);
-
-        $client->users->create([
-            'email' => 'test@intercom.io'
-        ]);
-
-        foreach ($container as $transaction) {
-            $basic = $transaction['request']->getHeaders()['Authorization'][0];
-            $this->assertSame("Basic dTpw", $basic);
-        }
+        HttpClientDiscovery::prependStrategy(MockClientStrategy::class);
     }
 
-    public function testExtendedClient()
+    public function testBasicClient()
     {
-        $mock = new MockHandler([
+        $httpClient = new Client();
+        $httpClient->addResponse(
             new Response(200, ['X-Foo' => 'Bar'], "{\"foo\":\"bar\"}")
-        ]);
-
-        $container = [];
-        $history = Middleware::history($container);
-        $stack = HandlerStack::create($mock);
-        $stack->push($history);
-
-        $httpClient = $this->httpClient(new GuzzleClient(['handler' => $stack, 'connect_timeout' => 10]));
+        );
 
         $client = new IntercomClient('u', 'p');
         $client->setHttpClient($httpClient);
@@ -60,24 +34,18 @@ class IntercomClientTest extends TestCase
             'email' => 'test@intercom.io'
         ]);
 
-        foreach ($container as $transaction) {
-            $options = $transaction['options'];
-            $this->assertSame(10, $options['connect_timeout']);
+        foreach ($httpClient->getRequests() as $request) {
+            $basic = $request->getHeaders()['Authorization'][0];
+            $this->assertSame("Basic dTpw", $basic);
         }
     }
 
     public function testClientWithExtraHeaders()
     {
-        $mock = new MockHandler([
+        $httpClient = new Client();
+        $httpClient->addResponse(
             new Response(200, ['X-Foo' => 'Bar'], "{\"foo\":\"bar\"}")
-        ]);
-
-        $container = [];
-        $history = Middleware::history($container);
-        $stack = HandlerStack::create($mock);
-        $stack->push($history);
-
-        $httpClient = $this->httpClient(new GuzzleClient(['handler' => $stack]));
+        );
 
         $client = new IntercomClient('u', 'p', ['Custom-Header' => 'value']);
         $client->setHttpClient($httpClient);
@@ -86,8 +54,8 @@ class IntercomClientTest extends TestCase
             'email' => 'test@intercom.io'
         ]);
 
-        foreach ($container as $transaction) {
-            $headers = $transaction['request']->getHeaders();
+        foreach ($httpClient->getRequests() as $request) {
+            $headers = $request->getHeaders();
             $this->assertSame('application/json', $headers['Accept'][0]);
             $this->assertSame('application/json', $headers['Content-Type'][0]);
             $this->assertSame('value', $headers['Custom-Header'][0]);
@@ -96,16 +64,11 @@ class IntercomClientTest extends TestCase
 
     public function testClientErrorHandling()
     {
-        $mock = new MockHandler([
+        $httpClient = new Client();
+        $httpClient->addResponse(
             new Response(404)
-        ]);
-
-        $container = [];
-        $history = Middleware::history($container);
-        $stack = HandlerStack::create($mock);
-        $stack->push($history);
-
-        $httpClient = $this->httpClient(new GuzzleClient(['handler' => $stack]));
+        );
+        $httpClient = new PluginClient($httpClient, [new ErrorPlugin()]);
 
         $client = new IntercomClient('u', 'p');
         $client->setHttpClient($httpClient);
@@ -118,16 +81,11 @@ class IntercomClientTest extends TestCase
 
     public function testServerErrorHandling()
     {
-        $mock = new MockHandler([
+        $httpClient = new Client();
+        $httpClient->addResponse(
             new Response(500)
-        ]);
-
-        $container = [];
-        $history = Middleware::history($container);
-        $stack = HandlerStack::create($mock);
-        $stack->push($history);
-
-        $httpClient = $this->httpClient(new GuzzleClient(['handler' => $stack]));
+        );
+        $httpClient = new PluginClient($httpClient, [new ErrorPlugin()]);
 
         $client = new IntercomClient('u', 'p');
         $client->setHttpClient($httpClient);
@@ -140,16 +98,10 @@ class IntercomClientTest extends TestCase
 
     public function testPaginationHelper()
     {
-        $mock = new MockHandler([
+        $httpClient = new Client();
+        $httpClient->addResponse(
             new Response(200, ['X-Foo' => 'Bar'], "{\"foo\":\"bar\"}")
-        ]);
-
-        $container = [];
-        $history = Middleware::history($container);
-        $stack = HandlerStack::create($mock);
-        $stack->push($history);
-
-        $httpClient = $this->httpClient(new GuzzleClient(['handler' => $stack]));
+        );
 
         $client = new IntercomClient('u', 'p');
         $client->setHttpClient($httpClient);
@@ -159,8 +111,8 @@ class IntercomClientTest extends TestCase
 
         $client->nextPage($pages);
 
-        foreach ($container as $transaction) {
-            $host = $transaction['request']->getUri()->getHost();
+        foreach ($httpClient->getRequests() as $request) {
+            $host = $request->getUri()->getHost();
             $this->assertSame("foo.com", $host);
         }
     }
@@ -169,7 +121,9 @@ class IntercomClientTest extends TestCase
     {
         date_default_timezone_set('UTC');
         $time = time() + 7;
-        $mock = new MockHandler([
+
+        $httpClient = new Client();
+        $httpClient->addResponse(
             new Response(
                 200,
                 [
@@ -179,14 +133,7 @@ class IntercomClientTest extends TestCase
                 ],
                 "{\"foo\":\"bar\"}"
             )
-        ]);
-
-        $container = [];
-        $history = Middleware::history($container);
-        $stack = HandlerStack::create($mock);
-        $stack->push($history);
-
-        $httpClient = $this->httpClient(new GuzzleClient(['handler' => $stack]));
+        );
 
         $client = new IntercomClient('u', 'p');
         $client->setHttpClient($httpClient);

--- a/tests/IntercomClientTest.php
+++ b/tests/IntercomClientTest.php
@@ -8,10 +8,8 @@ use GuzzleHttp\Handler\MockHandler;
 use GuzzleHttp\HandlerStack;
 use GuzzleHttp\Middleware;
 use GuzzleHttp\Psr7\Response;
-use Http\Adapter\Guzzle6\Client;
 use Http\Client\Exception;
 use Intercom\IntercomClient;
-use PHPUnit\Framework\TestCase;
 use stdClass;
 
 class IntercomClientTest extends TestCase
@@ -27,7 +25,7 @@ class IntercomClientTest extends TestCase
         $stack = HandlerStack::create($mock);
         $stack->push($history);
 
-        $httpClient = new Client(new GuzzleClient(['handler' => $stack]));
+        $httpClient = $this->httpClient(new GuzzleClient(['handler' => $stack]));
 
         $client = new IntercomClient('u', 'p');
         $client->setHttpClient($httpClient);
@@ -53,7 +51,7 @@ class IntercomClientTest extends TestCase
         $stack = HandlerStack::create($mock);
         $stack->push($history);
 
-        $httpClient = new Client(new GuzzleClient(['handler' => $stack, 'connect_timeout' => 10]));
+        $httpClient = $this->httpClient(new GuzzleClient(['handler' => $stack, 'connect_timeout' => 10]));
 
         $client = new IntercomClient('u', 'p');
         $client->setHttpClient($httpClient);
@@ -79,7 +77,7 @@ class IntercomClientTest extends TestCase
         $stack = HandlerStack::create($mock);
         $stack->push($history);
 
-        $httpClient = new Client(new GuzzleClient(['handler' => $stack]));
+        $httpClient = $this->httpClient(new GuzzleClient(['handler' => $stack]));
 
         $client = new IntercomClient('u', 'p', ['Custom-Header' => 'value']);
         $client->setHttpClient($httpClient);
@@ -107,7 +105,7 @@ class IntercomClientTest extends TestCase
         $stack = HandlerStack::create($mock);
         $stack->push($history);
 
-        $httpClient = new Client(new GuzzleClient(['handler' => $stack]));
+        $httpClient = $this->httpClient(new GuzzleClient(['handler' => $stack]));
 
         $client = new IntercomClient('u', 'p');
         $client->setHttpClient($httpClient);
@@ -129,7 +127,7 @@ class IntercomClientTest extends TestCase
         $stack = HandlerStack::create($mock);
         $stack->push($history);
 
-        $httpClient = new Client(new GuzzleClient(['handler' => $stack]));
+        $httpClient = $this->httpClient(new GuzzleClient(['handler' => $stack]));
 
         $client = new IntercomClient('u', 'p');
         $client->setHttpClient($httpClient);
@@ -151,7 +149,7 @@ class IntercomClientTest extends TestCase
         $stack = HandlerStack::create($mock);
         $stack->push($history);
 
-        $httpClient = new Client(new GuzzleClient(['handler' => $stack]));
+        $httpClient = $this->httpClient(new GuzzleClient(['handler' => $stack]));
 
         $client = new IntercomClient('u', 'p');
         $client->setHttpClient($httpClient);
@@ -188,7 +186,7 @@ class IntercomClientTest extends TestCase
         $stack = HandlerStack::create($mock);
         $stack->push($history);
 
-        $httpClient = new Client(new GuzzleClient(['handler' => $stack]));
+        $httpClient = $this->httpClient(new GuzzleClient(['handler' => $stack]));
 
         $client = new IntercomClient('u', 'p');
         $client->setHttpClient($httpClient);

--- a/tests/TestCase.php
+++ b/tests/TestCase.php
@@ -2,8 +2,13 @@
 
 namespace Intercom\Test;
 
+use GuzzleHttp\Client as GuzzleClient;
+use Http\Adapter\Guzzle6\Client as Guzzle6Client;
+use Http\Adapter\Guzzle7\Client as Guzzle7Client;
+use Http\Client\HttpClient;
 use Intercom\IntercomClient;
 use PHPUnit\Framework\TestCase as BaseTestCase;
+use RuntimeException;
 
 abstract class TestCase extends BaseTestCase
 {
@@ -12,7 +17,18 @@ abstract class TestCase extends BaseTestCase
      */
     protected $client;
 
-    protected function setUp()
+    protected function httpClient(GuzzleClient $guzzleClient): HttpClient
+    {
+        if (class_exists(Guzzle7Client::class)) {
+            return new Guzzle7Client($guzzleClient);
+        } elseif (class_exists(Guzzle6Client::class)) {
+            return new Guzzle6Client($guzzleClient);
+        } else {
+            throw new \RuntimeException('No supported Guzzle adapter class found');
+        }
+    }
+
+    protected function setUp(): void
     {
         parent::setUp();
 

--- a/tests/TestCase.php
+++ b/tests/TestCase.php
@@ -2,13 +2,8 @@
 
 namespace Intercom\Test;
 
-use GuzzleHttp\Client as GuzzleClient;
-use Http\Adapter\Guzzle6\Client as Guzzle6Client;
-use Http\Adapter\Guzzle7\Client as Guzzle7Client;
-use Http\Client\HttpClient;
 use Intercom\IntercomClient;
 use PHPUnit\Framework\TestCase as BaseTestCase;
-use RuntimeException;
 
 abstract class TestCase extends BaseTestCase
 {
@@ -16,17 +11,6 @@ abstract class TestCase extends BaseTestCase
      * @var IntercomClient|\PHPUnit\Framework\MockObject\MockObject
      */
     protected $client;
-
-    protected function httpClient(GuzzleClient $guzzleClient): HttpClient
-    {
-        if (class_exists(Guzzle7Client::class)) {
-            return new Guzzle7Client($guzzleClient);
-        } elseif (class_exists(Guzzle6Client::class)) {
-            return new Guzzle6Client($guzzleClient);
-        } else {
-            throw new \RuntimeException('No supported Guzzle adapter class found');
-        }
-    }
 
     protected function setUp(): void
     {


### PR DESCRIPTION
This PR was originally made by @edudobay on https://github.com/intercom/intercom-php/pull/335 but for some reason that PR is refusing to kick off CI 😭 

#### Why?
Provide compatibility with PHP 8.0 (released yesterday).

#### How?
Guzzle 6 supports PHP <= 7.4 and Guzzle 7 supports PHP 7.2 - 8.0.

Moving to mock-client removes the dependency from Guzzle 6, allowing Guzzle users to upgrade to any version freely.