### PR TITLE
Fix testing class name to be same as PHP file name

### DIFF
--- a/tests/IntercomSegmentsTest.php
+++ b/tests/IntercomSegmentsTest.php
@@ -4,7 +4,7 @@ namespace Intercom\Test;
 
 use Intercom\IntercomSegments;
 
-class IntercomSegmentTest extends TestCase
+class IntercomSegmentsTest extends TestCase
 {
     public function testSegmentList()
     {


### PR DESCRIPTION
#### Why?

Fix testing class name to be same as PHP file name.
