### PR TITLE
Add create conversation method

### DIFF
--- a/README.md
+++ b/README.md
@@ -433,6 +433,18 @@ $client->messages->create([
 
 ```php
 /**
+ * Create a conversation
+ * See more options here: https://developers.intercom.com/intercom-api-reference/reference#create-a-conversation
+ */
+$client->conversations->create([
+    'body' => 'Hello.',
+    'from' => [
+        'id' => '1234',
+        'type' => 'user',
+    ],
+]);
+
+/**
  * List conversations for an admin
  * See more options here: https://developers.intercom.io/reference#list-conversations
  */

--- a/src/IntercomConversations.php
+++ b/src/IntercomConversations.php
@@ -8,6 +8,19 @@ use stdClass;
 class IntercomConversations extends IntercomResource
 {
     /**
+     * Creates a Conversation.
+     *
+     * @see    https://developers.intercom.com/intercom-api-reference/reference#create-a-conversation
+     * @param  array $options
+     * @return stdClass
+     * @throws Exception
+     */
+    public function create(array $options)
+    {
+        return $this->client->post('conversations', $options);
+    }
+
+    /**
      * Returns list of Conversations.
      *
      * @see    https://developers.intercom.io/reference#list-conversations

--- a/tests/IntercomConversationsTest.php
+++ b/tests/IntercomConversationsTest.php
@@ -7,6 +7,14 @@ use stdClass;
 
 class IntercomConversationsTest extends TestCase
 {
+    public function testConversationCreate()
+    {
+        $this->client->method('post')->willReturn('foo');
+
+        $conversations = new IntercomConversations($this->client);
+        $this->assertSame('foo', $conversations->create([]));
+    }
+
     public function testConversationsList()
     {
         $this->client->method('get')->willReturn('foo');


### PR DESCRIPTION
#### Why?
- Creating conversation API is not covered
  - https://developers.intercom.com/intercom-api-reference/reference#create-a-conversation

#### How?
- Add `create` method to `IntercomConversations` class
- Add test
- Update README
