### PR TITLE
Fixed cursor pagination when different page size is used.

### DIFF
--- a/src/IntercomClient.php
+++ b/src/IntercomClient.php
@@ -294,9 +294,14 @@ class IntercomClient
      * @param string $startingAfter
      * @return stdClass
      */
-    public function nextCursorPage(string $path, string $startingAfter)
+    public function nextCursorPage(string $path, $pages)
     {
-        return $this->get($path . "?starting_after=" . $startingAfter);
+        $queryParams = [
+            "starting_after" => $pages->next->starting_after,
+            "per_page" => $pages->per_page,
+        ];
+
+        return $this->get($path, $queryParams);
     }
 
     /**

--- a/src/IntercomContacts.php
+++ b/src/IntercomContacts.php
@@ -118,8 +118,7 @@ class IntercomContacts extends IntercomResource
     public function nextCursor($pages)
     {
         $path = 'contacts';
-        $starting_after = $pages->next->starting_after;
-        return $this->client->nextCursorPage($path, $starting_after);
+        return $this->client->nextCursorPage($path, $pages);
     }
 
     /**

--- a/tests/IntercomClientTest.php
+++ b/tests/IntercomClientTest.php
@@ -117,6 +117,29 @@ class IntercomClientTest extends TestCase
         }
     }
 
+    public function testCursorHelper()
+    {
+        $httpClient = new Client();
+        $httpClient->addResponse(
+            new Response(200, ['X-Foo' => 'Bar'], "{\"foo\":\"bar\"}")
+        );
+
+        $client = new IntercomClient('u', 'p');
+        $client->setHttpClient($httpClient);
+
+        $pages = new stdClass;
+        $pages->per_page = 150;
+        $pages->next = new stdClass;
+        $pages->next->starting_after = "abc";
+
+        $client->nextCursorPage('path', $pages);
+
+        foreach ($httpClient->getRequests() as $request) {
+            $query = $request->getUri()->getQuery();
+            $this->assertSame("starting_after=abc&per_page=150", $query);
+        }
+    }
+
     public function testRateLimitDetails()
     {
         date_default_timezone_set('UTC');

--- a/tests/IntercomContactsTest.php
+++ b/tests/IntercomContactsTest.php
@@ -68,11 +68,12 @@ class IntercomContactsTest extends TestCase
         $this->assertSame('foo', $contacts->nextSearch([], $pages));
     }
 
-    public function testConversationNextCursor()
+    public function testContactNextCursor()
     {
         $this->client->method('nextCursorPage')->willReturn('foo');
         $query = [];
         $pages = new stdClass;
+        $pages->per_page = 150;
         $pages->next = new stdClass;
         $pages->next->starting_after = "abc";
 


### PR DESCRIPTION
#### Why?
When using cursor pagination on the get all contacts endpoint, the page size set is not taken into account.

#### How?
Passed the full `pages` object to the client's `nextCursorPage` helper and built the query parameters in a standard way.
