### PR TITLE
Update Company::update method to support providing an id.

### DIFF
--- a/src/IntercomCompanies.php
+++ b/src/IntercomCompanies.php
@@ -28,9 +28,17 @@ class IntercomCompanies extends IntercomResource
      * @return stdClass
      * @throws Exception
      */
-    public function update($options)
+    public function update($id, array $options = null)
     {
-        return $this->create($options);
+        // BC layer
+        if (func_num_args() < 2 || is_array($id)) {
+            @trigger_deprecation('intercom/intercom-php', '4.4', 'Specify an id or use create method');
+
+            return $this->create($id);
+        }
+
+        return $this->client->put($this->companyPath($id), $options);
+
     }
 
     /**

--- a/src/IntercomCompanies.php
+++ b/src/IntercomCompanies.php
@@ -31,14 +31,14 @@ class IntercomCompanies extends IntercomResource
     public function update($id, array $options = null)
     {
         // BC layer
+        // TODO: Next Major : Remove this.
         if (func_num_args() < 2 || is_array($id)) {
-            @trigger_deprecation('intercom/intercom-php', '4.4', 'Specify an id or use create method');
+            @trigger_error('Specify an id or use create method to update the company', E_USER_DEPRECATED);
 
             return $this->create($id);
         }
 
         return $this->client->put($this->companyPath($id), $options);
-
     }
 
     /**


### PR DESCRIPTION
Allow update method to update a specified company with an id.

#### Why?
The API supports the update via ID but not the SDK. There is a workaround but it is not clean to use directly the client. 

#### How?
I added the ID in the arguments of the update method and added a BC layer to avoid breaking apps or having to bump a major version. 

On next major version, the BC layer will need to be removed. 
