### PR TITLE
Contact attribute for type is `role`

### DIFF
--- a/README.md
+++ b/README.md
@@ -107,7 +107,7 @@ This resource is only available in API Versions 2.0 and above
 $client->contacts->create([
     'custom_attributes' => ['nickname' => 'Teddy'],
     'email' => 'test@example.com',
-    'type' => 'user',
+    'role' => 'user',
 ]);
 
 /** Update a contact */


### PR DESCRIPTION
Fixed a small typo in the create contact call, the attribute for setting the type is `role`, not `type` (which is actually the object type, `contact`). Unfortunately the API doesn't error with this example but every contact is the default `user` type,

#### Why?
Documentation bug
