### PR TITLE
Add merge contact method

### DIFF
--- a/README.md
+++ b/README.md
@@ -122,6 +122,12 @@ $client->contacts->deleteContact('570680a8a1bcbca8a90001b9');
 /** Get a contact by ID */
 $client->contacts->getContact('570680a8a1bcbca8a90001b9');
 
+/** Merge a contact to a User */
+$client->contacts->mergeContact([
+    'from' => '570680a8a1bcbca8a90001b9',
+    'into' => '59c124f770e00fd819b9ce81',
+]);
+
 /** Search for contacts */
 $query = ['field' => 'name', 'operator' => '=', 'value' => 'Alice'];
 $client->contacts->search([

--- a/src/IntercomContacts.php
+++ b/src/IntercomContacts.php
@@ -79,6 +79,19 @@ class IntercomContacts extends IntercomResource
     }
 
     /**
+     * Merge a contact to a User.
+     *
+     * @see    https://developers.intercom.com/intercom-api-reference/reference#merge-contact
+     * @param  array $options
+     * @return stdClass
+     * @throws Exception
+     */
+    public function mergeContact(array $options)
+    {
+        return $this->client->post("contacts/merge", $options);
+    }
+
+    /**
      * Returns list of Contacts that match search query.
      *
      * @see     https://developers.intercom.com/reference#search-for-contacts

--- a/tests/IntercomContactsTest.php
+++ b/tests/IntercomContactsTest.php
@@ -47,6 +47,14 @@ class IntercomContactsTest extends TestCase
         $this->assertSame('foo', $contacts->deleteContact(''));
     }
 
+    public function testContactMerge()
+    {
+        $this->client->method('post')->willReturn('foo');
+
+        $contacts = new IntercomContacts($this->client);
+        $this->assertSame('foo', $contacts->mergeContact([]));
+    }
+
     public function testContactSearch()
     {
         $this->client->method('post')->willReturn('foo');


### PR DESCRIPTION
#### Why?

 - Merging contact API is not covered
    - https://developers.intercom.com/intercom-api-reference/reference#merge-contact


#### How?
- Add merge contact method to IntercomContacts class
- Add test
- Update README
