### PR TITLE
Add custom attributes tip

### DIFF
--- a/README.md
+++ b/README.md
@@ -374,7 +374,7 @@ $client->companies->update([
     'name' => 'foocorp',
 ]);
 
-/** Create or update a company with custom attributes. */
+/** Create or update a company with custom attributes. 💁 TIP: First you need to create custom attributes via your company settings. */
 $client->companies->update([
     'custom_attributes' => [
         'short_name' => 'ABC Inc.',


### PR DESCRIPTION
Include a tip to indicate that custom attributes need to first be created via the company settings.

#### Why?
We were unable to locate any information that indicated the custom attributes first had to be created before custom attributes could be created/updated for a company.

#### How?
Simply add a TIP above the `$client->companies->update([` line in the README.md
