### PR TITLE
Adds company contacts endpoint support

### DIFF
--- a/README.md
+++ b/README.md
@@ -392,6 +392,9 @@ $client->companies->getCompany('531ee472cce572a6ec000006');
 /** List users belonging to a company by ID */
 $client->companies->getCompanyUsers('531ee472cce572a6ec000006');
 
+/** List attached contacts belonging to a company by ID */
+$client->companies->getCompanyContacts('531ee472cce572a6ec000006');
+
 /** List users belonging to a company by company_id */
 $client->companies->getCompanies([
     'company_id' => '3',

--- a/src/IntercomCompanies.php
+++ b/src/IntercomCompanies.php
@@ -129,6 +129,15 @@ class IntercomCompanies extends IntercomResource
     }
 
     /**
+     * @param string $id
+     * @return string
+     */
+    public function companyContactsPath($id)
+    {
+        return 'companies/' . $id . '/contacts';
+    }
+
+    /**
      * @param string $contactId
      * @return string
      */

--- a/src/IntercomCompanies.php
+++ b/src/IntercomCompanies.php
@@ -111,6 +111,21 @@ class IntercomCompanies extends IntercomResource
     }
 
     /**
+     * Returns a list of contacts belonging to a single Company based on the Intercom ID.
+     *
+     * @see    https://developers.intercom.com/intercom-api-reference/reference/listattachedcontacts
+     * @param  string $id
+     * @param  array  $options
+     * @return stdClass
+     * @throws Exception
+     */
+    public function getCompanyContacts($id, $options = [])
+    {
+        $path = $this->companyContactsPath($id);
+        return $this->client->get($path, $options);
+    }
+
+    /**
      * @param string $id
      * @return string
      */

--- a/tests/IntercomCompaniesTest.php
+++ b/tests/IntercomCompaniesTest.php
@@ -52,6 +52,14 @@ class IntercomCompaniesTest extends TestCase
         $this->assertSame('foo', $companies->getCompanyUsers("foo"));
     }
 
+    public function testCompanyGetContacts()
+    {
+        $this->client->method('get')->willReturn('foo');
+
+        $companies = new IntercomCompanies($this->client);
+        $this->assertSame('foo', $companies->getCompanyContacts("foo"));
+    }
+
     public function testCompanyUsersPath()
     {
         $users = new IntercomCompanies($this->client);


### PR DESCRIPTION
#### Why?
This change was made to add support to the following endpoint: https://developers.intercom.com/intercom-api-reference/reference/listattachedcontacts

#### How?
- Adding the path of the resource.
- Adding the function that sends the `GET` request, including the `ID` as a param and `options` in the query.
- Adding tests.
