### PR TITLE
Allow psr/http-message v2

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -40,7 +40,7 @@
         "php-http/discovery": "^1.4",
         "php-http/httplug": "^1.0 || ^2.0",
         "php-http/message": "^1.7",
-        "psr/http-message": "^1.0"
+        "psr/http-message": "^1.0 || ^2.0"
     },
     "require-dev": {
         "nyholm/psr7": "^1.6.1",


### PR DESCRIPTION
#### Why?

To support projects with `psr/http-message` `^2`

#### How?

Allow `^2.0` version in composer
