### PR TITLE
Make internal methods private

### DIFF
--- a/src/IntercomAdmins.php
+++ b/src/IntercomAdmins.php
@@ -41,7 +41,7 @@ class IntercomAdmins extends IntercomResource
      * @param  string $id
      * @return string
      */
-    public function adminPath($id)
+    private function adminPath($id)
     {
         return 'admins/' . $id;
     }

--- a/src/IntercomCompanies.php
+++ b/src/IntercomCompanies.php
@@ -114,7 +114,7 @@ class IntercomCompanies extends IntercomResource
      * @param string $id
      * @return string
      */
-    public function companyPath($id)
+    private function companyPath($id)
     {
         return 'companies/' . $id;
     }
@@ -123,7 +123,7 @@ class IntercomCompanies extends IntercomResource
      * @param string $id
      * @return string
      */
-    public function companyUsersPath($id)
+    private function companyUsersPath($id)
     {
         return 'companies/' . $id . '/users';
     }
@@ -132,17 +132,17 @@ class IntercomCompanies extends IntercomResource
      * @param string $contactId
      * @return string
      */
-    public function companyAttachPath(string $contactId)
+    private function companyAttachPath(string $contactId)
     {
         return 'contacts/' . $contactId . '/companies';
     }
-    
+
     /**
      * @param string $contactId
      * @param string $companyId
      * @return string
      */
-    public function companyDetachPath(string $contactId, string $companyId)
+    private function companyDetachPath(string $contactId, string $companyId)
     {
         return 'contacts/' . $contactId . '/companies/' . $companyId;
     }

--- a/src/IntercomContacts.php
+++ b/src/IntercomContacts.php
@@ -126,7 +126,7 @@ class IntercomContacts extends IntercomResource
      * @param string $id
      * @return string
      */
-    public function contactPath(string $id)
+    private function contactPath(string $id)
     {
         return 'contacts/' . $id;
     }

--- a/src/IntercomConversations.php
+++ b/src/IntercomConversations.php
@@ -127,7 +127,7 @@ class IntercomConversations extends IntercomResource
      * @param  string $id
      * @return string
      */
-    public function conversationPath($id)
+    private function conversationPath($id)
     {
         return 'conversations/' . $id;
     }
@@ -138,7 +138,7 @@ class IntercomConversations extends IntercomResource
      * @param  string $id
      * @return string
      */
-    public function conversationReplyPath($id)
+    private function conversationReplyPath($id)
     {
         return 'conversations/' . $id . '/reply';
     }

--- a/src/IntercomLeads.php
+++ b/src/IntercomLeads.php
@@ -90,17 +90,6 @@ class IntercomLeads extends IntercomResource
     }
 
     /**
-     * Returns endpoint path to Lead with given ID.
-     *
-     * @param  string $id
-     * @return string
-     */
-    public function leadPath($id)
-    {
-        return "contacts/" . $id;
-    }
-
-    /**
      * Gets a list of Leads through the contacts scroll API.
      *
      * @see    https://developers.intercom.com/v2.0/reference#iterating-over-all-leads
@@ -111,5 +100,16 @@ class IntercomLeads extends IntercomResource
     public function scrollLeads($options = [])
     {
         return $this->client->get('contacts/scroll', $options);
+    }
+
+    /**
+     * Returns endpoint path to Lead with given ID.
+     *
+     * @param  string $id
+     * @return string
+     */
+    private function leadPath($id)
+    {
+        return "contacts/" . $id;
     }
 }

--- a/src/IntercomTeams.php
+++ b/src/IntercomTeams.php
@@ -41,7 +41,7 @@ class IntercomTeams extends IntercomResource
      * @param  string $id
      * @return string
      */
-    public function teamPath($id)
+    private function teamPath($id)
     {
         return 'teams/' . $id;
     }

--- a/src/IntercomUsers.php
+++ b/src/IntercomUsers.php
@@ -122,7 +122,7 @@ class IntercomUsers extends IntercomResource
      * @param string $id
      * @return string
      */
-    public function userPath(string $id)
+    private function userPath(string $id)
     {
         return 'users/' . $id;
     }

--- a/src/IntercomVisitors.php
+++ b/src/IntercomVisitors.php
@@ -70,7 +70,7 @@ class IntercomVisitors extends IntercomResource
      * @param  string $id
      * @return string
      */
-    public function visitorPath($id)
+    private function visitorPath($id)
     {
         return "visitors/" . $id;
     }

--- a/tests/IntercomAdminsTest.php
+++ b/tests/IntercomAdminsTest.php
@@ -21,10 +21,4 @@ class IntercomAdminsTest extends TestCase
         $users = new IntercomAdmins($this->client);
         $this->assertSame('foo', $users->getAdmin(1));
     }
-
-    public function testAdminsGetPath()
-    {
-        $users = new IntercomAdmins($this->client);
-        $this->assertSame('admins/1', $users->adminPath(1));
-    }
 }

--- a/tests/IntercomCompaniesTest.php
+++ b/tests/IntercomCompaniesTest.php
@@ -30,12 +30,6 @@ class IntercomCompaniesTest extends TestCase
         $this->assertSame('foo', $companies->getCompanies([]));
     }
 
-    public function testCompanyPath()
-    {
-        $users = new IntercomCompanies($this->client);
-        $this->assertSame('companies/foo', $users->companyPath("foo"));
-    }
-
     public function testCompanyGetById()
     {
         $this->client->method('get')->willReturn('foo');
@@ -50,11 +44,5 @@ class IntercomCompaniesTest extends TestCase
 
         $companies = new IntercomCompanies($this->client);
         $this->assertSame('foo', $companies->getCompanyUsers("foo"));
-    }
-
-    public function testCompanyUsersPath()
-    {
-        $users = new IntercomCompanies($this->client);
-        $this->assertSame('companies/foo/users', $users->companyUsersPath("foo"));
     }
 }

--- a/tests/IntercomConversationsTest.php
+++ b/tests/IntercomConversationsTest.php
@@ -23,12 +23,6 @@ class IntercomConversationsTest extends TestCase
         $this->assertSame('foo', $users->getConversations([]));
     }
 
-    public function testConversationPath()
-    {
-        $users = new IntercomConversations($this->client);
-        $this->assertSame('conversations/foo', $users->conversationPath("foo"));
-    }
-
     public function testGetConversation()
     {
         $this->client->method('get')->willReturn('foo');
@@ -56,12 +50,6 @@ class IntercomConversationsTest extends TestCase
 
         $conversations = new IntercomConversations($this->client);
         $this->assertSame('foo', $conversations->nextSearch([], $pages));
-    }
-
-    public function testConversationReplyPath()
-    {
-        $users = new IntercomConversations($this->client);
-        $this->assertSame('conversations/foo/reply', $users->conversationReplyPath("foo"));
     }
 
     public function testReplyToConversation()

--- a/tests/IntercomLeadsTest.php
+++ b/tests/IntercomLeadsTest.php
@@ -30,13 +30,6 @@ class IntercomLeadsTest extends TestCase
         $this->assertSame('foo', $leads->getLeads([]));
     }
 
-    public function testLeadPath()
-    {
-
-        $leads = new IntercomLeads($this->client);
-        $this->assertSame("contacts/foo", $leads->leadPath("foo"));
-    }
-
     public function testLeadsGet()
     {
         $this->client->method('get')->willReturn('foo');

--- a/tests/IntercomTeamsTest.php
+++ b/tests/IntercomTeamsTest.php
@@ -21,10 +21,4 @@ class IntercomTeamsTest extends TestCase
         $teams = new IntercomTeams($this->client);
         $this->assertSame('foo', $teams->getTeam(1));
     }
-
-    public function testTeamsGetPath()
-    {
-        $teams = new IntercomTeams($this->client);
-        $this->assertSame('teams/1', $teams->teamPath(1));
-    }
 }

--- a/tests/IntercomVisitorsTest.php
+++ b/tests/IntercomVisitorsTest.php
@@ -14,12 +14,6 @@ class IntercomVisitorsTest extends TestCase
         $this->assertSame('foo', $visitors->update([]));
     }
 
-    public function testVisitorPath()
-    {
-        $visitors = new IntercomVisitors($this->client);
-        $this->assertSame("visitors/foo", $visitors->visitorPath("foo"));
-    }
-
     public function testVisitorsGet()
     {
         $this->client->method('get')->willReturn('foo');


### PR DESCRIPTION
#### Why?
There are many identical public methods called `somethingPath()`.
They are 100% internal. 
There is no need to expose them to the outside world. 
Moreover, these methods clutter the public interface and confuse the clients of the code.

The idea is to make them `private`.

#### How?
Methods are made private, redundant tests removed (as we don't test private methods).
