### PR TITLE
Make `IntercomClient::$password` explicitly nullable

### DIFF
--- a/src/IntercomClient.php
+++ b/src/IntercomClient.php
@@ -145,7 +145,7 @@ class IntercomClient
      * @param string|null $password Api Key.
      * @param array $extraRequestHeaders Extra request headers to be sent in every api request
      */
-    public function __construct(string $appIdOrToken, string $password = null, array $extraRequestHeaders = [])
+    public function __construct(string $appIdOrToken, ?string $password = null, array $extraRequestHeaders = [])
     {
         $this->users = new IntercomUsers($this);
         $this->contacts = new IntercomContacts($this);


### PR DESCRIPTION
This prevents a deprecation warning from showing up since PHP 8.4

```
Deprecated: Intercom\IntercomClient::__construct(): Implicitly marking parameter $password as nullable is deprecated, the explicit nullable type must be used instead in /<redacted-path>/vendor/intercom/intercom-php/src/IntercomClient.php on line 148
```
