### PR TITLE
Removing unnecessary version attribute

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -1,13 +1,13 @@
 {
   "name": "intercom/intercom-php",
-  "version": "0.0.325",
+
   "description": "Intercom API client.",
   "keywords": [
     "intercom",
     "api",
     "sdk"
   ],
-  "license": [],
+  "license": "MIT",
   "require": {
     "php": "^8.1",
     "ext-json": "*",
@@ -36,9 +36,11 @@
     "test": "phpunit",
     "analyze": "phpstan analyze src tests --memory-limit=1G"
   },
-  "author": {
-    "name": "Intercom Platform Team",
-    "url": "https://www.intercom.com"
-  },
+  "authors": [
+    {
+      "name": "Intercom Platform Team",
+      "homepage": "https://www.intercom.com"
+    }
+  ],
   "homepage": "https://developers.intercom.com/docs"
 }


### PR DESCRIPTION
Getting this issue in packagist, preventing us from pushing the new SDK
<img width="904" height="487" alt="Screenshot 2025-08-27 at 15 14 59" src="https://github.com/user-attachments/assets/0d60e296-a907-439f-ae67-e5e7dce4fa7e" />

Packagist recommended following this post, so I did what they suggested: https://blog.packagist.com/tagged-a-new-release-for-composer-and-it-wont-show-up-on-packagist/